### PR TITLE
implement: web-of-trust

### DIFF
--- a/docs/web-of-trust.md
+++ b/docs/web-of-trust.md
@@ -1,0 +1,528 @@
+# Web of Trust: a Social Graph Overlay
+
+**Status:** Proposed (revision 1)
+**Scope:** `chr33s/git` — builds on the trust and hub design in
+[hub.md](hub.md) (`refs/meta/trust/*`, `refs/hub/*`, the policy boundary,
+delegated credentials) and the agent identity model in
+[agents.md](agents.md). Nothing here changes hub v1; every construct is an
+overlay a repository or a verifier opts into.
+**Social namespace:** `refs/social/*` (in a principal's identity repository)
+
+---
+
+## 1. The problem: trust is an island per repository
+
+Hub v1 answers "who may do what **here**" completely: a genesis roots a
+quorum, a hash-linked trust log grows grants and revocations, and every
+event verifies offline against that one repository's own history. What it
+deliberately does not answer is anything **between** repositories or
+**between people**:
+
+```text
+identity      a member IS their SSH key; rotate the key in one
+              repository and every other repository still grants
+              the old one. There is no "same person" across repos.
+
+introduction  known_repos is blind TOFU: the first connection to a
+              repository is an unverifiable leap, even when people
+              you already trust have been using it for years.
+
+discovery     there is no way to find a repository, its mirrors, or
+              its forks except out-of-band. A decentralized forge
+              with no discovery layer quietly re-centralizes around
+              whoever runs the index.
+
+federation    a fork and its parent share objects and nothing else.
+              A pull request cannot carry review weight from anyone
+              the target repository has not individually granted.
+```
+
+A web of trust fills exactly these gaps: **signed, append-only statements
+by principals about other principals and about repositories**, replicated
+as git refs like everything else, and projected **per verifier** — never
+into a global score.
+
+The design constraint carried over from hub.md, restated once because
+every section below leans on it: the authoritative representation is git
+objects and refs; verification is offline; omission must be visible;
+projections are deterministic folds; and no construct may widen authority
+that the repository's own policy did not grant.
+
+---
+
+## 2. Principals: identity as a repository
+
+The unit of the social graph is a **principal**, and a principal is an
+**identity repository** — the same genesis/quorum/log machinery hub v1
+already ships, reused one level up:
+
+```text
+PrincipalID = RepoID of the principal's identity repository
+            = SHA-256(genesis blob bytes)
+```
+
+An individual initializes 1-of-1; an organization N-of-M. The identity
+repository's own trust log (`refs/meta/trust/log`) holds the principal's
+**device and agent keys** as ordinary grants:
+
+```text
+principal genesis (1-of-1, Alice's offline key)
+        ↓
+trust.grant  laptop key      (expires yearly)
+trust.grant  phone key
+trust.grant  CI-agent key    (capabilities: ["sign.check"])
+trust.revoke laptop key      (reason: "compromised")
+```
+
+This buys the thing bare keys cannot: **rotation without loss of
+identity, and one revocation that propagates everywhere**. A repository
+that granted membership to a `PrincipalID` (§5) rather than to a key
+picks up the rotation on its next trust sync; a compromise revocation in
+the identity log reaches every repository that resolves through it, with
+the retroactive semantics of hub.md §10 intact.
+
+Nothing forces this. A bare SSH key remains a valid subject everywhere it
+is one today; a principal is what a key holder graduates to when they
+have more than one key, more than one repository, or an agent fleet
+(agents.md Part I becomes "grant the agent a key **in your identity
+repository**" instead of "grant it in every project").
+
+An identity repository is fetched, pinned and verified exactly like any
+other repository: `known_repos` gains entries whose value is a
+PrincipalID, and the checkpoint-staleness bound (hub.md §9) bounds how
+old a view of someone's key set a verifier will accept for high-value
+decisions.
+
+---
+
+## 3. The social log
+
+A principal's statements about the world live in their identity
+repository under one append-only, hash-linked ref, shaped exactly like
+the trust log — commits whose trees carry one signed payload, parents the
+prior head(s), first parent the genesis commit:
+
+```text
+refs/social/log
+```
+
+Everything hub.md specifies for append-only namespaces applies verbatim:
+boundary-enforced no-delete and ancestry-preserving updates, a walk
+ceiling, namespace-capability charging (`social.write`, granted in the
+identity repository's own trust log), duplicate-ID resolution by descent,
+checkpoints, and advertisement hygiene (hidden from v0 source-only
+clients, `ref-prefix` under v2).
+
+### Statement kinds
+
+```text
+social.attest.repo        URL ↔ RepoID binding, with a role
+social.attest.principal   key or name ↔ PrincipalID binding
+social.vouch              delegatable, attenuated trust in a principal
+social.follow             subscription / replication hint
+social.revoke             withdrawal of any prior statement
+social.checkpoint         signed frontier attestation
+```
+
+All payloads carry the author's PrincipalID, a UUIDv7 statement ID, and
+the declared social-log head — the same self-declared-head + floor
+discipline as hub events — and are SSH-signed under the existing
+namespace with a distinct type field, so a signature over a vouch can
+never verify as a grant.
+
+### `social.attest.repo` — introduction
+
+```json
+{
+  "type": "social.attest.repo",
+  "repo": "SHA256:bJd3cN8...",
+  "urls": ["https://git.example.com/acme/project"],
+  "role": "origin",
+  "forkOf": null,
+  "issuedAt": "2026-08-20T00:00:00Z"
+}
+```
+
+"I have verified that this RepoID answers at these URLs." `role` is one
+of `origin | mirror | fork`; a `fork` names `forkOf`. This is the
+statement that turns blind TOFU into introduction (§4) and URL moves into
+recognition, and the statement whose union across a verifier's web is a
+decentralized index of repositories, mirrors and fork graphs (§7).
+
+### `social.attest.principal` — key endorsement
+
+```json
+{
+  "type": "social.attest.principal",
+  "subject": "principal:SHA256:9f2c...",
+  "publicKey": "ssh-ed25519 AAAA...",
+  "claim": "key-of",
+  "issuedAt": "2026-08-20T00:00:00Z"
+}
+```
+
+The PGP key-signing statement, repaid in SSH: "I verified, out of band,
+that this key answers to this principal." Useful for bootstrapping a
+principal whose identity repository a verifier cannot reach yet, and for
+cross-checking one they can.
+
+### `social.vouch` — attenuated, delegatable trust
+
+```json
+{
+  "type": "social.vouch",
+  "subject": "principal:SHA256:9f2c...",
+  "scope": ["introduce.repo", "review"],
+  "depth": 1,
+  "issuedAt": "2026-08-20T00:00:00Z",
+  "expiresAt": "2027-08-20T00:00:00Z"
+}
+```
+
+"Within `scope`, I trust this principal's word — and (`depth` ≥ 1) the
+word of those they vouch for, `depth` hops further." Scopes are
+capability-shaped and small:
+
+```text
+introduce.repo     their repo attestations count for my TOFU decisions
+introduce.key      their principal attestations count
+review             their reviews may satisfy policies that opt in (§6)
+vouch              they may extend my web (this is what depth spends)
+```
+
+Two rules make chains safe, and both are the delegated-credential rules
+of hub.md §12 generalized:
+
+```text
+attenuation   effective scope along a chain is the INTERSECTION of
+              every link's scope; effective depth is the MINIMUM of
+              remaining depths. A chain can only ever narrow.
+
+no widening   nothing reachable through the web grants a capability
+              in any repository. The web supplies candidates and
+              confidence; authority is only ever what a repository's
+              own trust log and policy say (§6).
+```
+
+### `social.follow`
+
+```json
+{ "type": "social.follow", "subject": "principal:SHA256:9f2c..." }
+```
+
+A follow carries **no trust at all**. It is a replication hint — "fetch
+this identity repository's social log when synchronizing mine" — and the
+edge that makes the graph traversable for discovery. Keeping follow and
+vouch separate is deliberate: conflating subscription with endorsement is
+how social platforms turn reach into authority, and the projection rules
+below never read follows.
+
+### `social.revoke`
+
+Withdraws a prior statement by ID, with the windowed semantics of
+hub.md §10 — every window a statement has been out on is kept, an
+ordinary revoke is forward-only from acceptance, and
+`reason: "compromised"` on a vouch reaches backwards so that
+introductions and reviews that flowed through a compromised link are
+re-projected without it.
+
+---
+
+## 4. Projection: every verifier is their own root
+
+There is **no global graph and no global score**. A projection is a fold
+a verifier runs from their own configuration:
+
+```text
+roots:      my own identity repository, plus principals I have
+            explicitly vouched (my direct edges are depth ∞ to me)
+statements: the union of social logs I hold locally (fetched via
+            follows and on demand)
+fold:       breadth-first from my roots along vouch edges only,
+            intersecting scopes and decrementing depth per hop,
+            dropping revoked windows, stopping at depth 0
+answer:     for a (subject, scope) question: the set of INDEPENDENT
+            paths that reach it, with each path's effective scope
+```
+
+Deterministic given the same statement set — same discipline as hub
+projection, and cacheable the same way (memoised against the social-log
+heads it read, keyed per verifier, disposable).
+
+**Independent paths are the unit of confidence.** A verifier's policy
+for any decision is `minPaths: k` — paths sharing no intermediate
+principal — because one bad voucher then only ever contributes one path.
+This is the classic web-of-trust marginal/complete distinction made
+explicit and tunable.
+
+**Sybil resistance is structural, not statistical.** A million fabricated
+principals vouching for each other are reachable from a verifier's roots
+by exactly zero paths. The web is safe from inflation precisely because
+it refuses to compute anything unrooted; any future ranking that sums
+over the whole graph re-opens the hole and is out of scope permanently.
+
+---
+
+## 5. Application: introduction, and cross-repository membership
+
+### TOFU becomes introduction
+
+`git+ hub enable` today, meeting an unknown RepoID, can only ask the
+user to leap. With the overlay it first asks the verifier's own web:
+
+```text
+The authenticity of repository
+  https://git.example.com/acme/project
+can be established through your web of trust:
+
+  attested by alice (direct), bob (via alice, depth 1)
+  2 independent paths · scope introduce.repo · RepoID matches
+
+Trust this repository? [yes/no]
+```
+
+`known_repos` entries gain a provenance field — `tofu` or
+`introduced(k paths)` — and a repository moving hosts stops being a
+fresh leap: a new URL attested by the same web for the same RepoID is
+recognition (hub.md §5's "moves" case, now signed instead of
+coincidental). Conflicting attestations for one URL are surfaced as the
+split-view warning, never resolved silently. A verifier with no web, or
+`minPaths` unmet, falls back to exactly today's blind TOFU — the overlay
+strictly adds information.
+
+### Membership by PrincipalID
+
+A repository's `trust.grant` may name a principal instead of a key:
+
+```json
+{
+  "type": "trust.grant",
+  "repo": "SHA256:bJd3cN8...",
+  "subject": "principal:SHA256:9f2c...",
+  "identityRepo": { "pin": "SHA256:9f2c...", "hint": ["https://..."] },
+  "capabilities": ["source.push", "hub.review", "hub.approve"],
+  "issuedAt": "2026-08-20T00:00:00Z",
+  "expiresAt": "2027-08-20T00:00:00Z"
+}
+```
+
+Resolution at the policy boundary becomes a two-log question: is the
+presenting key currently granted in the subject's identity log, and is
+the subject granted here? The machinery this needs already exists:
+
+```text
+pinning      the grant pins the PrincipalID; the identity repository
+             is fetched and verified like any repository. The hint
+             is a hint — identity is the pin, never the URL.
+
+staleness    the checkpoint-age bound (hub.md §9) applies to the
+             foreign log: a high-value operation may require a
+             fresh-enough view of the member's own key set.
+
+ordering     identity logs synchronize before the repositories that
+             reference them — the "trust before hub" rule (hub.md
+             §23) gains one earlier stage, and an event whose
+             signer's identity log has not replicated yet is
+             QUARANTINED and re-validated, not rejected.
+
+permanence   any verdict hub.md holds permanent (tombstones) must
+             pin the identity-log head it judged against, exactly
+             as it pins the trust head today — a permanent answer
+             may not depend on a log that moves.
+```
+
+What this buys, concretely: one `trust.revoke` of a stolen laptop key in
+Alice's identity repository, and every repository that granted
+`principal:alice` refuses that key at its next trust sync — today that is
+one revocation per repository, and the ones nobody remembers are the
+breach.
+
+---
+
+## 6. Application: federated forks and external review
+
+`social.attest.repo` with `role: "fork"` makes the fork graph a
+first-class, verifier-computable object, which enables cross-repository
+pull requests without any shared host:
+
+```text
+fork F attests   {role: fork, forkOf: R}
+origin R's maintainers attest F back (or not — the edge is
+  directional, and R's policy decides what F's edges are worth)
+
+a pr.opened in R names a head that R does not hold; the fork
+  attestation tells a synchronizing client WHERE to fetch it,
+  and object transfer needs nothing new — a pack is a pack
+```
+
+Review weight from outside the membership is the sharpest tool here and
+the most dangerous, so it is **policy opt-in, per branch, with the web
+supplying candidates and the policy supplying the bar** — never the
+reverse. In `refs/meta/policy`:
+
+```json
+{
+  "branch": "refs/heads/main",
+  "requiredApprovals": 2,
+  "externalReview": {
+    "anchors": [
+      "principal:SHA256:maintainer1...",
+      "principal:SHA256:maintainer2..."
+    ],
+    "scope": "review",
+    "maxDepth": 1,
+    "minPaths": 2,
+    "maxCount": 1
+  }
+}
+```
+
+read as: at most one of the required approvals may come from a principal
+reachable with scope `review` within one hop from **the repository's own
+named anchors** — not from the pusher's web, which would let anyone
+bring their own reviewers. The projection is the anchors' vouch fold,
+run by the policy boundary with the same determinism, floors and
+staleness bounds as every other fold it makes; self-approval exclusion
+and the capability hierarchy of hub.md §27 apply unchanged. A repository
+that never writes `externalReview` never folds it.
+
+---
+
+## 7. Application: discovery and replication
+
+Follows make the graph crawlable, and `attest.repo` statements make it
+useful. A client synchronizing its own identity repository also fetches
+the social logs of followed principals (bounded: direct follows by
+default, `--depth` to go further), and the local union answers:
+
+```text
+git+ social find <name-or-RepoID>   repositories my web attests,
+                                    with URLs, roles, fork graph
+git+ social mirrors <repo>          attested mirrors, freshest first
+git+ social who <key>               principals my web binds a key to
+```
+
+This is the forge's directory function with no directory: the index is
+whatever your corner of the web has said, replicates as refs, works
+offline, and degrades to nothing worse than today (out-of-band URLs)
+when the web is silent. Hosts MAY additionally run open aggregate
+indexes for search; those are caches over signed statements anyone can
+re-verify — convenience infrastructure, never authority, exactly the
+"projection caches are disposable" rule.
+
+---
+
+## 8. What the overlay refuses to be
+
+Stated as sharply as the hub spec states its limits:
+
+```text
+no global reputation   any number computed over the whole graph is
+                       a Sybil target and a centralization magnet.
+                       Every answer is rooted at a verifier.
+
+no automatic authority the web never satisfies a capability check.
+                       It introduces, corroborates and nominates;
+                       repositories decide (§6), and a repository
+                       that ignores refs/social/* entirely loses
+                       nothing hub v1 promised it.
+
+no follow-as-trust     follows are plumbing for replication and
+                       discovery; the fold never reads them.
+
+no hidden edges as     the graph is public where it exists at all.
+  a privacy story      A social log is replicated, signed history:
+                       publishing "alice vouches bob" is a choice
+                       made by writing it. Principals who want
+                       unlinkable contexts run multiple identity
+                       repositories — cheap by design — rather than
+                       trusting an overlay to hide edges it
+                       replicates. Payload redaction (tombstones,
+                       hub.md §21) removes content, never the fact
+                       of a statement.
+```
+
+And one honest limitation inherited from every offline-verifiable
+system: **freshness is best-effort**. A withheld revocation of a vouch
+is visible as a stale frontier and bounded by checkpoint age, not
+prevented — same property, same mitigation, same sentence as hub.md §9.
+
+---
+
+## 9. Threats specific to the overlay
+
+```text
+vouch-chain laundering   attenuation (intersection + min-depth) means
+                         a chain never exceeds its narrowest link;
+                         minPaths means one subverted principal
+                         contributes one path, not a verdict.
+
+introduction poisoning   conflicting attest.repo for one URL is a
+                         surfaced split-view, and RepoID (exact
+                         genesis bytes) is what is being attested —
+                         a lookalike genesis is a different RepoID,
+                         so the poison has to be in the verifier's
+                         own web to count at all.
+
+identity-repo capture    a captured identity repository is a captured
+                         principal — quorum thresholds, offline root
+                         keys and the unrecoverable-by-design rule
+                         (hub.md §6) apply; repositories that granted
+                         the principal bound themselves to that
+                         quorum, which is the risk stated plainly.
+
+graph spam / log growth  writing to a social log costs social.write
+                         in that identity repository — you can only
+                         spam yourself. Ceilings, duplicate-ID
+                         descent resolution and walk bounds carry
+                         over verbatim; a verifier fetches logs it
+                         follows, so unwanted logs are never even
+                         held.
+
+cross-log replay         every statement carries the author's
+                         PrincipalID inside the signed bytes, as
+                         every trust event carries RepoID today.
+```
+
+---
+
+## 10. Implementation shape
+
+The point of §2–§3 reusing existing machinery is that this is mostly
+composition, in the pattern of [plan.md](plan.md):
+
+```text
+src/social/
+  Statement.ts       payload schemas, signing (over src/crypto)
+  Log.ts             append/read (the trust Log generalized over
+                     a namespace, which §23's rules already are)
+  Projection.ts      rooted fold: attenuation, depth, minPaths,
+                     revocation windows, memoised per verifier
+  Introduce.ts       known_repos v2: provenance, introduction
+                     resolution, split-view surfacing
+
+src/trust/           subject: "principal:" resolution — the
+                     two-log membership walk, quarantine, pinned
+                     identity-log heads
+
+src/server/Policy.ts externalReview evaluation at the boundary
+
+src/cli/
+  id.ts              git+ id init | rotate | revoke | status
+  social.ts          git+ follow | vouch | attest | social find
+```
+
+Phasing, each independently shippable and each useful without the next:
+
+```text
+1  identity repositories + PrincipalID grants   (rotation story)
+2  social log + attest.repo + introduction      (TOFU story)
+3  vouch + rooted projection + minPaths         (the web itself)
+4  discovery commands + follow-driven fetch     (the forge story)
+5  externalReview policy                        (federation story)
+```
+
+Phase 1 has no social graph in it at all and is worth shipping alone;
+phase 5 is the only one that lets the overlay near an authorization
+decision, and it arrives last, behind a policy field nobody has written
+yet.

--- a/docs/web-of-trust.md
+++ b/docs/web-of-trust.md
@@ -532,10 +532,7 @@ reverse. In `refs/meta/policy`:
   "branch": "refs/heads/main",
   "requiredApprovals": 2,
   "externalReview": {
-    "anchors": [
-      "principal:SHA256:maintainer1...",
-      "principal:SHA256:maintainer2..."
-    ],
+    "anchors": ["principal:SHA256:maintainer1...", "principal:SHA256:maintainer2..."],
     "scope": "review",
     "maxDepth": 1,
     "minPaths": 2,

--- a/docs/web-of-trust.md
+++ b/docs/web-of-trust.md
@@ -1,12 +1,39 @@
 # Web of Trust: a Social Graph Overlay
 
-**Status:** Proposed (revision 1)
+**Status:** Proposed (revision 2)
 **Scope:** `chr33s/git` — builds on the trust and hub design in
 [hub.md](hub.md) (`refs/meta/trust/*`, `refs/hub/*`, the policy boundary,
 delegated credentials) and the agent identity model in
 [agents.md](agents.md). Nothing here changes hub v1; every construct is an
 overlay a repository or a verifier opts into.
 **Social namespace:** `refs/social/*` (in a principal's identity repository)
+
+## Revision 2 changes
+
+Prior art from the nostr protocol ([NIPs](https://github.com/nostr-protocol/nips))
+reviewed and folded in:
+
+```text
+1. social.mirrors: self-published locations for one's own
+   identity repository — the outbox model (NIP-65).
+2. attest.repo gains lineage (earliest-unique-commit fork-family
+   key, NIP-34) and inbox (a contribution door for non-members).
+3. Follows carry petnames; verifiers build petname tables
+   (NIP-02) instead of consulting any global namespace.
+4. attest.principal gains external-identity claims with
+   bidirectional proofs (NIP-39); DNS-based names admitted as
+   attestations by a domain, never as identity (NIP-05).
+5. Shareable identifiers: typed, checksummed encodings bundling
+   an ID with location hints (NIP-19/21), and a git-remote
+   helper so stock git clones by identity (NIP-34).
+6. social.label: namespaced labels instead of a new statement
+   kind per vocabulary (NIP-32).
+7. Delegated projection for weak clients — signed, attributed,
+   explicitly chosen providers (NIP-85's mechanism, with its
+   global metrics rejected).
+8. Prior-art section (§10) recording what nostr's deployment
+   proves and what is deliberately not borrowed.
+```
 
 ---
 
@@ -93,6 +120,38 @@ PrincipalID, and the checkpoint-staleness bound (hub.md §9) bounds how
 old a view of someone's key set a verifier will accept for high-value
 decisions.
 
+### Shareable identifiers
+
+A bare `SHA256:bJd3cN8...` has no type, no checksum and no location.
+Identifiers meant for humans to share — pasted in a message, printed in
+a README, rendered as a QR code — SHOULD use a typed bech32m encoding
+that bundles the ID with up to a few URL hints, the NIP-19 pattern:
+
+```text
+gid1...     a PrincipalID, optionally with mirror hints
+grepo1...   a RepoID, optionally with clone-URL hints
+```
+
+Typed prefixes make pasting the wrong kind of thing a decode error
+rather than a lookup that half-works; the checksum catches truncation;
+and the embedded hints make the identifier self-locating. Hints are
+**bootstrap only**: resolution ends at the pinned identity (TOFU or
+introduction), and a hint is never trusted over the pin. Encoded forms
+are for display and exchange — logs and payloads store the canonical
+`SHA256:` form, exactly as NIP-19 keeps bech32 out of its core protocol.
+
+A `git-remote` helper (the mechanism NIP-34 uses to make `nostr://`
+clone URLs work with stock git) completes it:
+
+```text
+git clone git+id://grepo1...
+```
+
+resolves the RepoID through `known_repos`, the verifier's web and the
+subject's `social.mirrors` statements (§3), so a clone starts from
+_identity_ and discovers _location_ — the inversion of every hosted
+forge, where the URL is the name.
+
 ---
 
 ## 3. The social log
@@ -117,9 +176,12 @@ clients, `ref-prefix` under v2).
 
 ```text
 social.attest.repo        URL ↔ RepoID binding, with a role
-social.attest.principal   key or name ↔ PrincipalID binding
+social.attest.principal   key or external identity ↔ PrincipalID
+social.mirrors            self-published locations of one's own
+                          repositories (the outbox)
 social.vouch              delegatable, attenuated trust in a principal
-social.follow             subscription / replication hint
+social.follow             subscription / replication hint, with petname
+social.label              namespaced label on any subject
 social.revoke             withdrawal of any prior statement
 social.checkpoint         signed frontier attestation
 ```
@@ -139,6 +201,8 @@ never verify as a grant.
   "urls": ["https://git.example.com/acme/project"],
   "role": "origin",
   "forkOf": null,
+  "lineage": "sha1:a1b2c3...",
+  "inbox": "https://git.example.com/acme/project",
   "issuedAt": "2026-08-20T00:00:00Z"
 }
 ```
@@ -148,6 +212,19 @@ of `origin | mirror | fork`; a `fork` names `forkOf`. This is the
 statement that turns blind TOFU into introduction (§4) and URL moves into
 recognition, and the statement whose union across a verifier's web is a
 decentralized index of repositories, mirrors and fork graphs (§7).
+
+`lineage` is the repository's **earliest unique commit** — the root
+commit, or the first commit after a permanent fork — borrowed from
+NIP-34's `euc` tag. It is computable from any clone with no trust in
+anyone, and it answers a different question than the two identities
+above: `RepoID` says _same authority_ (same genesis quorum), `lineage`
+says _same line of code_. Discovery uses it to cluster a project's
+forks and mirrors across hosts before anyone has attested a single
+fork edge (§7).
+
+`inbox` names where a **non-member** may send a proposed change (§6) —
+the door NIP-34's "patches to the announced relays" holds open and this
+design otherwise lacks. Both fields are optional.
 
 ### `social.attest.principal` — key endorsement
 
@@ -165,6 +242,60 @@ The PGP key-signing statement, repaid in SSH: "I verified, out of band,
 that this key answers to this principal." Useful for bootstrapping a
 principal whose identity repository a verifier cannot reach yet, and for
 cross-checking one they can.
+
+A second claim kind links a principal to an **external identity**
+(NIP-39's shape), which is how the web bootstraps from social capital
+that already exists on centralized forges:
+
+```json
+{
+  "type": "social.attest.principal",
+  "subject": "principal:SHA256:9f2c...",
+  "claim": "external-identity",
+  "identity": "github:alice",
+  "proof": "https://gist.github.com/alice/...",
+  "issuedAt": "2026-08-20T00:00:00Z"
+}
+```
+
+The proof MUST be bidirectional: the named platform account publishes a
+statement naming the PrincipalID, and the attestation points at it.
+Self-attested, it is a claim anyone can check; attested by others, it is
+their word that they checked. DNS-based names (`alice@example.com`
+resolving through `/.well-known/`, NIP-05's mechanism) are admitted the
+same way — as an attestation whose author is _the current controller of
+that domain_, a rented binding displayed as such. A name is never the
+identity; nostr's deployment history is the case study in why (§10).
+
+### `social.mirrors` — the outbox
+
+```json
+{
+  "type": "social.mirrors",
+  "repo": "self",
+  "urls": [
+    { "url": "https://git.alice.dev/id", "mode": "write" },
+    { "url": "https://mirror.example.com/alice-id", "mode": "read" }
+  ],
+  "issuedAt": "2026-08-20T00:00:00Z"
+}
+```
+
+A principal's own, self-published answer to "where do I live" — the
+outbox model, nostr's censorship-resistance workhorse (NIP-65). `repo`
+is `"self"` for the identity repository or a RepoID the principal
+maintains. Resolution of anything that names this principal — a
+`principal:` grant (§5), an encoded identifier (§2), a follow — SHOULD
+follow the subject's newest `social.mirrors` statement in preference to
+any hint written by somebody else, because the subject is the one party
+with both the knowledge and the incentive to keep it current.
+
+NIP-65's operational discipline transfers with it: keep the list small
+(a few entries), and spread the statement widely — it is the one
+statement worth pushing beyond one's own mirrors, since it is how
+everything else gets found. "Newest supersedes" is expressed as a log
+entry projected to latest, never as an overwrite — the replaceable-event
+failure mode is one of the rejections in §10.
 
 ### `social.vouch` — attenuated, delegatable trust
 
@@ -207,7 +338,11 @@ no widening   nothing reachable through the web grants a capability
 ### `social.follow`
 
 ```json
-{ "type": "social.follow", "subject": "principal:SHA256:9f2c..." }
+{
+  "type": "social.follow",
+  "subject": "principal:SHA256:9f2c...",
+  "petname": "alice"
+}
 ```
 
 A follow carries **no trust at all**. It is a replication hint — "fetch
@@ -216,6 +351,34 @@ edge that makes the graph traversable for discovery. Keeping follow and
 vouch separate is deliberate: conflating subscription with endorsement is
 how social platforms turn reach into authority, and the projection rules
 below never read follows.
+
+`petname` is a display name **local to the author** (NIP-02's petname
+scheme): this design already refuses global human-readable names, and
+petnames are the constructive half of that refusal. A client renders
+principals by its own petnames first, then by names reachable through
+its web ("alice's bob"), then by the encoded identifier — so what a name
+means depends only on whose log said it, and there is no namespace to
+squat.
+
+### `social.label` — namespaced labels
+
+```json
+{
+  "type": "social.label",
+  "subject": "repo:SHA256:bJd3cN8...",
+  "namespace": "org.example.licenses",
+  "label": "MIT",
+  "issuedAt": "2026-08-20T00:00:00Z"
+}
+```
+
+The extensibility valve (NIP-32's `L`/`l` pattern): topics, licenses,
+content warnings and moderation verdicts are all "author says X about
+subject", and giving each its own statement kind means spec churn for
+every vocabulary. A label's `namespace` is reverse-domain notation, its
+meaning belongs to whoever defines that namespace, and a label counts
+for a verifier exactly as far as its author's word does under the fold —
+distributed moderation with no global moderator falls out for free.
 
 ### `social.revoke`
 
@@ -313,7 +476,11 @@ the subject granted here? The machinery this needs already exists:
 ```text
 pinning      the grant pins the PrincipalID; the identity repository
              is fetched and verified like any repository. The hint
-             is a hint — identity is the pin, never the URL.
+             is a hint — identity is the pin, never the URL — and
+             resolution prefers the subject's own newest
+             social.mirrors statement (§3) over the grant's static
+             hint, which was written once by somebody else and
+             goes stale the way all such hints do.
 
 staleness    the checkpoint-age bound (hub.md §9) applies to the
              foreign log: a high-value operation may require a
@@ -386,6 +553,21 @@ staleness bounds as every other fold it makes; self-approval exclusion
 and the capability hierarchy of hub.md §27 apply unchanged. A repository
 that never writes `externalReview` never folds it.
 
+### The inbox: contribution without membership
+
+NIP-34 lets anyone send a patch to a repository's announced relays;
+the equivalent front door here is the `inbox` a repository's
+self-attestation names (§3). A stranger with no membership pushes their
+proposed change — a branch of ordinary commits — to the inbox, where it
+lands **quarantined**: held, excluded from projection, exactly the state
+hub.md §23 already defines for events whose authorization does not yet
+resolve. A member reviews the quarantined proposal and adopts it into a
+pull request under their own signature, or a maintainer grants the
+stranger `hub.create-pr` and the proposal graduates to an ordinary
+pull request of their own. The authority model is not weakened — nothing
+quarantined counts for anything — but the drive-by patch, the workflow
+git was built for and hosted forges gated behind accounts, is back.
+
 ---
 
 ## 7. Application: discovery and replication
@@ -409,6 +591,29 @@ when the web is silent. Hosts MAY additionally run open aggregate
 indexes for search; those are caches over signed statements anyone can
 re-verify — convenience infrastructure, never authority, exactly the
 "projection caches are disposable" rule.
+
+`lineage` (§3) clusters before anyone has vouched for anything: every
+clone can compute its own earliest unique commit, so the forks and
+mirrors of one project group together even in a web that has said
+nothing about them yet, and an `attest.repo` naming a lineage the local
+clone does not compute is a discrepancy worth surfacing.
+
+### Delegated projection
+
+A phone-class client cannot fold a large web, and nostr's answer
+(NIP-85) is worth taking in mechanism while refusing in content: a
+client MAY name **projection providers** — hosts that publish signed,
+attributed snapshots of specific folds (an introduction index, a vouch
+projection from named roots) — and accept their answers in place of
+folding locally. The conditions carry over from NIP-85 and tighten:
+the provider is chosen explicitly per question (never a default), uses
+a distinct signing key per algorithm so answers are attributable and
+providers swappable, and signs the input frontier (the log heads the
+fold read) so a full client can re-run the fold and catch a lying
+provider. What providers computed for nostr — global ranks, follower
+counts — is exactly what §8 forbids; the delegation is of _work_, never
+of _rooting_: a provider answers "what does the fold from YOUR roots
+say", not "who is trustworthy".
 
 ---
 
@@ -486,7 +691,69 @@ cross-log replay         every statement carries the author's
 
 ---
 
-## 10. Implementation shape
+## 10. Prior art: nostr
+
+Nostr is the largest deployed system of signed statements flowing over
+dumb relays, and its NIPs are a field report on which decentralization
+mechanisms carry weight in practice. What its deployment proves, and
+this design leans on: **the social layer does the decentralizing**.
+Follows, self-published relay lists (outbox) and repository
+announcements are what let nostr survive relays disappearing; its trust
+primitives stayed weak, and the network held together anyway. That is
+the same division of labor drawn here — discovery and introduction in
+the social log, authority in per-repository trust logs.
+
+Borrowed, with the section that absorbed each: the outbox model
+(NIP-65 → `social.mirrors`, §3), the earliest-unique-commit lineage key
+and the git-remote-helper clone URL (NIP-34 → §3, §2), petnames
+(NIP-02 → §3), external-identity proofs (NIP-39 → §3), DNS names as
+domain attestations (NIP-05 → §3), typed shareable encodings
+(NIP-19/21 → §2), namespaced labels (NIP-32 → §3), the anyone-can-send
+contribution door (NIP-34 → §6), and delegated projection with
+attributable provider keys (NIP-85 → §7).
+
+Deliberately not borrowed:
+
+```text
+flat keypair identity    nostr's acknowledged structural weakness:
+                         key rotation never landed, so a leaked
+                         nsec is a lost identity. Identity
+                         repositories (§2) exist to not have this
+                         problem.
+
+replaceable events       kind-0/3/10002 "latest timestamp wins,
+                         delete the old one" loses history silently
+                         and makes omission invisible — the bag-of-
+                         refs failure hub.md §9 rejects. Latest-
+                         supersedes semantics here are log entries
+                         projected to latest (§3), never overwrites.
+
+global WoT metrics       NIP-85's ranks and follower counts are
+                         unrooted aggregates — Sybil bait and a
+                         centralization magnet around whoever
+                         computes them (§8). The mechanism was
+                         taken; the metrics were not.
+
+relay-honored deletion   NIP-09 deletion is a request relays MAY
+                         honor; tombstones here are policy-enforced
+                         and replicate as first-class state
+                         (hub.md §21). Stronger already; nothing to
+                         take.
+
+proof of work            NIP-13 rate-limits an open write surface.
+                         Social logs are capability-gated — you can
+                         only spam yourself (§9) — so PoW earns at
+                         most a footnote for open aggregate indexes
+                         (§7), which are caches, not authority.
+
+negentropy sync          NIP-77 rebuilds set reconciliation that
+                         git's own negotiation already provides
+                         over refs (hub.md §23).
+```
+
+---
+
+## 11. Implementation shape
 
 The point of §2–§3 reusing existing machinery is that this is mostly
 composition, in the pattern of [plan.md](plan.md):
@@ -500,6 +767,8 @@ src/social/
                      revocation windows, memoised per verifier
   Introduce.ts       known_repos v2: provenance, introduction
                      resolution, split-view surfacing
+  Encode.ts          gid1/grepo1 bech32m encodings, and the
+                     git-remote helper that resolves them (§2)
 
 src/trust/           subject: "principal:" resolution — the
                      two-log membership walk, quarantine, pinned
@@ -516,13 +785,17 @@ Phasing, each independently shippable and each useful without the next:
 
 ```text
 1  identity repositories + PrincipalID grants   (rotation story)
-2  social log + attest.repo + introduction      (TOFU story)
+2  social log + attest.repo + mirrors +
+   introduction                                 (TOFU story)
 3  vouch + rooted projection + minPaths         (the web itself)
-4  discovery commands + follow-driven fetch     (the forge story)
-5  externalReview policy                        (federation story)
+4  discovery + follows/petnames + encoded
+   identifiers + remote helper + labels         (the forge story)
+5  externalReview policy + the inbox            (federation story)
 ```
 
 Phase 1 has no social graph in it at all and is worth shipping alone;
 phase 5 is the only one that lets the overlay near an authorization
 decision, and it arrives last, behind a policy field nobody has written
-yet.
+yet. External-identity proofs and delegated projection providers slot
+into phases 2 and 4 respectively as optional extensions — neither is on
+any other phase's critical path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "effect": "4.0.0-rc.110"
       },
       "bin": {
-        "git+": "src/cli/bin.ts"
+        "git+": "src/cli/bin.ts",
+        "git-remote-git+id": "src/cli/remote-id.node.ts"
       },
       "devDependencies": {
         "@chr33s/base-wc": "github:chr33s/base-wc",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Universal Git smart-HTTP protocol server, browser client & nix cli",
   "license": "MIT",
   "bin": {
-    "git+": "./src/cli/bin.ts"
+    "git+": "./src/cli/bin.ts",
+    "git-remote-git+id": "./src/cli/remote-id.node.ts"
   },
   "files": [
     "src",

--- a/src/cli/hub.ts
+++ b/src/cli/hub.ts
@@ -28,6 +28,10 @@ import { stores } from "../git/Node.ts";
 import * as GitRepository from "../git/Repository.ts";
 import * as Refspec from "../git/Refspec.ts";
 import { ObjectStore, RefStore } from "../git/Store.ts";
+import * as Introduce from "../social/Introduce.ts";
+import * as SocialLog from "../social/Log.ts";
+import * as SocialProjection from "../social/Projection.ts";
+import { localSocialWeb } from "../social/Web.node.ts";
 import * as Certificate from "../trust/Certificate.ts";
 import type { Oid } from "../git/Store.ts";
 import {
@@ -51,6 +55,13 @@ import {
 } from "../trust/KnownRepos.ts";
 import { layer as knownRepos } from "../trust/KnownRepos.node.ts";
 import * as Log from "../trust/Log.ts";
+import {
+  principalId,
+  principalOf,
+  principalSubject,
+  type PrincipalId,
+  type PrincipalSubject,
+} from "../trust/Principal.ts";
 import * as Record from "../trust/Record.ts";
 import { openWindow, project } from "../trust/Projection.ts";
 import { reconcile } from "../server/Replication.ts";
@@ -75,6 +86,31 @@ const localRepository = (directory: string) =>
   GitRepository.layer.pipe(
     Layer.provide(GitRepository.hooksNoop),
     Layer.provideMerge(stores(directory)),
+  );
+
+/** The rooted social view used to replace blind TOFU when the user names one. */
+const verifierWeb = (root: string, identityRepo: string) =>
+  withRepo(
+    root,
+    identityRepo,
+    Effect.gen(function* () {
+      const stored = yield* readGenesis();
+      if (stored === null) {
+        return yield* new Invalid({
+          field: "identity",
+          reason: `${identityRepo} is not an identity repository`,
+        });
+      }
+      const trust = yield* project(stored.genesis);
+      const own = yield* SocialLog.verified(stored.genesis, trust);
+      const web = yield* SocialProjection.SocialWeb;
+      const held = yield* web.logs;
+      const logs = new Map([...held, own].map((log) => [`${log.principal}\u0000${log.head}`, log]));
+      return SocialProjection.project({
+        roots: [principalId(stored.genesis.repoId)],
+        logs: [...logs.values()],
+      });
+    }).pipe(Effect.provide(localSocialWeb(root))),
   );
 
 /**
@@ -182,7 +218,7 @@ const grant = Command.make(
     root: rootFlag,
     key: keyFlag,
     subject: Flag.string("subject").pipe(
-      Flag.withDescription("Path to the member's SSH public key"),
+      Flag.withDescription("Path to an SSH public key, or principal:<PrincipalID>"),
     ),
     capability: Flag.string("capability").pipe(
       Flag.withDescription("Capabilities to grant, comma-separated"),
@@ -197,26 +233,36 @@ const grant = Command.make(
   ({ capability, expires, key, repo, root, subject }) =>
     Effect.gen(function* () {
       const signers = yield* Effect.forEach(key, readPrivateKey);
-      const publicKey = yield* readPublicKey(subject);
+      const stable = principalOf(subject);
+      const publicKey = stable === null ? yield* readPublicKey(subject) : null;
 
       const granted = yield* withRepo(
         root,
         repo,
         Effect.gen(function* () {
           const stored = yield* mustBeEnabled(repo);
-          const payload = yield* Certificate.grant({
+          const capabilities = capability.split(",").map((value) => value.trim());
+          const details = {
             repo: stored.genesis.repoId,
-            publicKey,
-            capabilities: capability.split(",").map((value) => value.trim()),
+            capabilities,
             expiresAt: expires === 0 ? null : new Date(Date.now() + expires * 1000),
             id: Log.newId(),
-          });
+          } as const;
+          const payload =
+            stable === null
+              ? publicKey === null
+                ? yield* new Invalid({ field: "subject", reason: "the public key was not read" })
+                : yield* Certificate.grant({ ...details, publicKey })
+              : yield* Certificate.grantPrincipal({ ...details, principal: stable });
           const commit = yield* Log.issue(payload, signers);
-          return yield* confirmMember(stored.genesis, commit, payload.subject);
+          return stable === null
+            ? yield* confirmMember(stored.genesis, commit, payload.subject)
+            : yield* confirmPrincipalMember(stored.genesis, commit, stable);
         }),
       );
 
-      yield* Console.log(`Granted ${granted.capabilities.join(",")} to ${granted.fingerprint}`);
+      const grantedSubject = "fingerprint" in granted ? granted.fingerprint : granted.principal;
+      yield* Console.log(`Granted ${granted.capabilities.join(",")} to ${grantedSubject}`);
     }),
 );
 
@@ -226,7 +272,7 @@ const revoke = Command.make(
     root: rootFlag,
     key: keyFlag,
     subject: Flag.string("subject").pipe(
-      Flag.withDescription("The member's key fingerprint (SHA256:…)"),
+      Flag.withDescription("A key fingerprint or principal:<PrincipalID>"),
     ),
     reason: Flag.choice("reason", ["rotated", "left", "compromised", "superseded"]).pipe(
       Flag.withDefault("left"),
@@ -241,22 +287,28 @@ const revoke = Command.make(
         repo,
         Effect.gen(function* () {
           const stored = yield* mustBeEnabled(repo);
-          if (!isFingerprint(subject)) {
+          const stable = principalOf(subject);
+          let revokedSubject: Fingerprint | PrincipalSubject;
+          if (stable !== null) {
+            revokedSubject = principalSubject(stable);
+          } else if (isFingerprint(subject)) {
+            revokedSubject = subject;
+          } else {
             return yield* new Invalid({
               field: "subject",
-              reason: `'${subject}' is not a key fingerprint; \`hub members\` lists them`,
+              reason: `'${subject}' is not a key fingerprint or principal:<PrincipalID>`,
             });
           }
           const commit = yield* Log.issue(
             Certificate.revoke({
               repo: stored.genesis.repoId,
-              subject,
+              subject: revokedSubject,
               reason,
               id: Log.newId(),
             }),
             signers,
           );
-          return yield* confirmRevoked(stored.genesis, commit, subject);
+          return yield* confirmRevoked(stored.genesis, commit, revokedSubject);
         }),
       );
       yield* Console.log(`Revoked ${subject} (${reason})`);
@@ -280,6 +332,13 @@ const members = Command.make("members", { root: rootFlag, repo: repoArgument }, 
           member.expiresAt === null ? "" : ` (expires ${member.expiresAt.toISOString()})`;
         yield* Console.log(`  ${member.fingerprint}  ${member.capabilities.join(",")}${expiry}`);
       }
+      for (const member of projection.principals.values()) {
+        const expiry =
+          member.expiresAt === null ? "" : ` (expires ${member.expiresAt.toISOString()})`;
+        yield* Console.log(
+          `  principal:${member.principal}  ${member.capabilities.join(",")}${expiry}`,
+        );
+      }
       for (const windows of projection.revoked.values()) {
         // A revocation a later grant ended stays on the record — it is still
         // true about the window it covers — but the key is a member again, and
@@ -287,6 +346,11 @@ const members = Command.make("members", { root: rootFlag, repo: repoArgument }, 
         const out = openWindow(windows);
         if (out === null) continue;
         yield* Console.log(`  ${out.subject}  revoked (${out.reason})`);
+      }
+      for (const windows of projection.revokedPrincipals.values()) {
+        const out = openWindow(windows);
+        if (out === null) continue;
+        yield* Console.log(`  principal:${out.subject}  revoked (${out.reason})`);
       }
       // Said out loud rather than swallowed: a record that did not count is
       // exactly what somebody will be looking for.
@@ -346,11 +410,27 @@ const confirmMember = Effect.fn("hub.confirmMember")(function* (
   return member;
 });
 
+const confirmPrincipalMember = Effect.fn("hub.confirmPrincipalMember")(function* (
+  genesis: Genesis,
+  commit: Oid,
+  subject: PrincipalId,
+) {
+  const projection = yield* confirm(genesis, commit);
+  const member = projection.principals.get(subject);
+  if (member === undefined) {
+    return yield* new Invalid({
+      field: "trust",
+      reason: `the grant to principal:${subject} did not take effect`,
+    });
+  }
+  return member;
+});
+
 /** And for a revocation, which has to have reached the subject to have worked. */
 const confirmRevoked = Effect.fn("hub.confirmRevoked")(function* (
   genesis: Genesis,
   commit: Oid,
-  subject: Fingerprint,
+  subject: Fingerprint | PrincipalSubject,
 ) {
   const projection = yield* confirm(genesis, commit);
   // The *open* window, not merely a record. A key that was revoked, let back
@@ -358,7 +438,14 @@ const confirmRevoked = Effect.fn("hub.confirmRevoked")(function* (
   // revoked on the strength of the old, closed window — telling an operator a
   // key is out when it is still authorized, which is the one direction this
   // message must never be wrong in.
-  if (openWindow(projection.revoked.get(subject)) === null) {
+  const stable = principalOf(subject);
+  const revoked =
+    stable === null
+      ? isFingerprint(subject)
+        ? openWindow(projection.revoked.get(subject))
+        : null
+      : openWindow(projection.revokedPrincipals.get(stable));
+  if (revoked === null) {
     return yield* new Invalid({
       field: "trust",
       reason: `${subject} is still authorized; the revocation did not take effect`,
@@ -532,22 +619,30 @@ const enable = Command.make(
       Flag.withDefault("origin"),
       Flag.withDescription("Local repository directory to fetch into"),
     ),
+    identity: Flag.string("identity").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Local identity repository whose web should evaluate first use"),
+    ),
+    minPaths: Flag.integer("min-paths").pipe(
+      Flag.withDefault(1),
+      Flag.withDescription("Independent introduction paths required from --identity"),
+    ),
     token: Flag.string("token").pipe(
       Flag.withDefault(""),
       Flag.withDescription("Credential for a repository that requires one"),
     ),
     url: Argument.string("url"),
   },
-  ({ name, root, token, url, yes }) =>
+  ({ identity: identityRepo, minPaths, name, root, token, url, yes }) =>
     Effect.gen(function* () {
       const key = yield* canonicalUrl(url);
       const directory = `${root}/${name}`;
 
       const credential = token === "" ? undefined : token;
-      const identity = yield* presented(url, credential).pipe(
+      const presentedId = yield* presented(url, credential).pipe(
         Effect.provide(localRepository(directory)),
       );
-      const decision = yield* decide(key, identity);
+      const decision = yield* decide(key, presentedId);
 
       if (decision.kind === "changed") {
         yield* Console.error(mismatchMessage(key, decision.expected, decision.presented));
@@ -558,13 +653,58 @@ const enable = Command.make(
       }
 
       if (decision.kind === "new") {
-        yield* Console.error(firstUseMessage(key, decision.repoId, decision.alias));
+        const social =
+          identityRepo === ""
+            ? null
+            : yield* Introduce.decide({
+                projection: yield* verifierWeb(root, identityRepo),
+                url: key,
+                presented: decision.repoId,
+                minPaths,
+              });
+        if (social?.kind === "split") {
+          yield* Console.error(
+            [
+              `Split-view warning for ${key}:`,
+              `  presented ${social.presented}`,
+              ...social.claims.map(
+                (claim) =>
+                  `  your web claims ${claim.repo} through ${claim.paths} independent path(s)`,
+              ),
+            ].join("\n"),
+          );
+          return yield* new Invalid({
+            field: "url",
+            reason: "the presented repository conflicts with the verifier's web",
+          });
+        }
+        const introduction = social?.kind === "introduced" ? social : null;
+        yield* Console.error(
+          introduction === null
+            ? firstUseMessage(key, decision.repoId, decision.alias)
+            : [
+                `The authenticity of repository`,
+                `  ${key}`,
+                `is attested by ${introduction.paths} independent path(s) through your web.`,
+                "",
+                `Repository fingerprint:`,
+                `  ${decision.repoId}`,
+                "",
+              ].join("\n"),
+        );
         const accepted = yes || (yield* ask("Trust this repository? [yes/no] "));
         if (!accepted) {
           return yield* new Invalid({ field: "url", reason: "not trusted; nothing was written" });
         }
         const store = yield* KnownRepos;
-        yield* store.remember({ url: key, repoId: decision.repoId });
+        yield* store.remember({
+          url: key,
+          repoId: decision.repoId,
+          provenance:
+            introduction === null
+              ? { kind: "tofu" }
+              : { kind: "introduced", paths: introduction.paths },
+        });
       }
 
       // Trust first, then hub: an event is judged against the membership graph,
@@ -599,7 +739,7 @@ const enable = Command.make(
       }).pipe(Effect.provide(localRepository(directory)));
 
       yield* Console.log(`${key}`);
-      yield* Console.log(`  ${identity}`);
+      yield* Console.log(`  ${presentedId}`);
       yield* Console.log(`  ${fetched.all.length} hub/trust ref(s) fetched into ${directory}`);
       if (fetched.joined.length > 0) {
         yield* Console.log(`  ${fetched.joined.length} divergent ref(s) joined`);

--- a/src/cli/id.test.ts
+++ b/src/cli/id.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, it } from "@effect/vitest";
+
+import { Effect } from "effect";
+
+import { serve, type Server } from "../host/Node.ts";
+import { writeKeyPair } from "../testing/Hub.ts";
+
+const execFileAsync = promisify(execFile);
+const entry = path.join(import.meta.dirname, "bin.ts");
+let root = "";
+
+const cli = async (args: ReadonlyArray<string>): Promise<string> => {
+  const result = await execFileAsync(process.execPath, [entry, ...args], { encoding: "utf8" });
+  return `${result.stdout}${result.stderr}`;
+};
+
+describe("cli identity and social graph", () => {
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "cli-id-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it.live("creates a PrincipalID and publishes a signed follow", () =>
+    Effect.promise(async () => {
+      const key = path.join(root, "identity-key");
+      await writeKeyPair(key, "alice@example.com");
+
+      const initialized = await cli(["id", "init", "--root", root, "--key", key, "alice"]);
+      const principal = /PrincipalID: (SHA256:[A-Za-z0-9+/]{43})/.exec(initialized)?.[1];
+      assert.notEqual(principal, undefined, initialized);
+      assert.match(initialized, /Shareable: gid1/);
+      if (principal === undefined) assert.fail(initialized);
+
+      const status = await cli(["id", "status", "--root", root, "alice"]);
+      assert.match(status, /source\.push,social\.write/);
+
+      const followed = await cli([
+        "social",
+        "follow",
+        "--root",
+        root,
+        "--key",
+        key,
+        "--name",
+        "alice",
+        principal,
+        "alice",
+      ]);
+      assert.match(followed, /social\.follow/);
+
+      const social = await cli(["social", "status", "--root", root, "alice"]);
+      assert.match(social, /1 active statement/);
+    }),
+  );
+
+  it.live("discovers attestations across locally synchronized identity repositories", () =>
+    Effect.promise(async () => {
+      const aliceKey = path.join(root, "alice-key");
+      const bobKey = path.join(root, "bob-key");
+      await writeKeyPair(aliceKey, "alice@example.com");
+      await writeKeyPair(bobKey, "bob@example.com");
+
+      const aliceInit = await cli(["id", "init", "--root", root, "--key", aliceKey, "alice"]);
+      const bobInit = await cli(["id", "init", "--root", root, "--key", bobKey, "bob"]);
+      const alice = /PrincipalID: (SHA256:[A-Za-z0-9+/]{43})/.exec(aliceInit)?.[1];
+      const bob = /PrincipalID: (SHA256:[A-Za-z0-9+/]{43})/.exec(bobInit)?.[1];
+      if (alice === undefined || bob === undefined) assert.fail(`${aliceInit}\n${bobInit}`);
+
+      await cli([
+        "social",
+        "vouch",
+        "--root",
+        root,
+        "--key",
+        aliceKey,
+        "--scope",
+        "introduce.repo",
+        bob,
+        "alice",
+      ]);
+      await cli([
+        "social",
+        "attest",
+        "--root",
+        root,
+        "--key",
+        bobKey,
+        "--url",
+        "https://code.example/alice",
+        alice,
+        "bob",
+      ]);
+
+      const found = await cli(["social", "find", "--root", root, alice, "alice"]);
+      assert.match(found, /https:\/\/code\.example\/alice/);
+      assert.match(found, /1 path\(s\)/);
+    }),
+  );
+
+  it.live("synchronizes followed identities from attested locations", () =>
+    Effect.promise(async () => {
+      const remoteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-id-remote-"));
+      let server: Server | null = null;
+      try {
+        const aliceKey = path.join(root, "alice-key");
+        const bobKey = path.join(remoteRoot, "bob-key");
+        await writeKeyPair(aliceKey, "alice@example.com");
+        await writeKeyPair(bobKey, "bob@example.com");
+
+        const aliceInit = await cli(["id", "init", "--root", root, "--key", aliceKey, "alice"]);
+        const bobInit = await cli(["id", "init", "--root", remoteRoot, "--key", bobKey, "bob"]);
+        const alice = /PrincipalID: (SHA256:[A-Za-z0-9+/]{43})/.exec(aliceInit)?.[1];
+        const bob = /PrincipalID: (SHA256:[A-Za-z0-9+/]{43})/.exec(bobInit)?.[1];
+        if (alice === undefined || bob === undefined) assert.fail(`${aliceInit}\n${bobInit}`);
+
+        server = await serve({ root: remoteRoot });
+        const location = `${server.url}/bob`;
+        await cli([
+          "social",
+          "follow",
+          "--root",
+          root,
+          "--key",
+          aliceKey,
+          "--name",
+          "bob",
+          bob,
+          "alice",
+        ]);
+        await cli([
+          "social",
+          "attest",
+          "--root",
+          root,
+          "--key",
+          aliceKey,
+          "--url",
+          location,
+          bob,
+          "alice",
+        ]);
+
+        const synced = await cli(["social", "sync", "--root", root, "alice"]);
+        assert.match(synced, /1 followed identity repo\(s\) synchronized/);
+        const cloned = (await fs.readdir(root)).find((name) => name.startsWith("gid1"));
+        assert.notEqual(cloned, undefined);
+        if (cloned === undefined) assert.fail("the followed identity was not materialized");
+        const status = await cli(["id", "status", "--root", root, cloned]);
+        assert.match(status, new RegExp(bob.replace(/[+/]/g, "\\$&")));
+      } finally {
+        if (server !== null) await server.close();
+        await fs.rm(remoteRoot, { recursive: true, force: true });
+      }
+    }),
+  );
+});

--- a/src/cli/id.ts
+++ b/src/cli/id.ts
@@ -1,0 +1,208 @@
+/** Stable principal identity repositories: bootstrap, rotate, revoke, inspect. */
+import { Console, Effect, Result } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { formatPublicKey, isFingerprint } from "../crypto/SshSignature.ts";
+import { Invalid } from "../git/Error.ts";
+import { encodePrincipal } from "../social/Encode.ts";
+import * as Certificate from "../trust/Certificate.ts";
+import { create, readGenesis, signGenesis, writeGenesis, type Genesis } from "../trust/Genesis.ts";
+import * as Log from "../trust/Log.ts";
+import { principalId } from "../trust/Principal.ts";
+import { openWindow, project } from "../trust/Projection.ts";
+import { readPrivateKey, readPublicKey, repoArgument, rootFlag, withRepo } from "./shared.ts";
+
+const rootKeys = Flag.string("root-key").pipe(
+  Flag.withDescription("Path to an offline root private key (repeat for a quorum)"),
+  Flag.atLeast(1),
+);
+
+const enabled = Effect.fn("cli.id.enabled")(function* (repo: string) {
+  const stored = yield* readGenesis();
+  if (stored === null) {
+    return yield* new Invalid({ field: "repo", reason: `${repo} is not an identity repository` });
+  }
+  return stored.genesis;
+});
+
+const confirm = Effect.fn("cli.id.confirm")(function* (genesis: Genesis, commit: string) {
+  const projection = yield* project(genesis);
+  const refused = projection.rejected.find((entry) => entry.commit === commit);
+  if (refused !== undefined) {
+    return yield* new Invalid({ field: "identity", reason: refused.reason });
+  }
+  return projection;
+});
+
+const init = Command.make(
+  "init",
+  {
+    root: rootFlag,
+    key: Flag.string("key").pipe(
+      Flag.withDescription("Path to a root private key (repeat for a quorum)"),
+      Flag.atLeast(1),
+    ),
+    threshold: Flag.integer("threshold").pipe(Flag.withDefault(1)),
+    repo: repoArgument,
+  },
+  ({ key, repo, root, threshold }) =>
+    Effect.gen(function* () {
+      const signers = yield* Effect.forEach(key, readPrivateKey);
+      const first = signers[0];
+      if (threshold < 1 || signers.length < threshold || first === undefined) {
+        return yield* new Invalid({
+          field: "threshold",
+          reason: `threshold ${threshold} needs at least ${threshold} root key(s)`,
+        });
+      }
+      const genesis = yield* create(
+        signers.map((signer) => formatPublicKey(signer.publicKey)),
+        threshold,
+      );
+      yield* withRepo(
+        root,
+        repo,
+        Effect.gen(function* () {
+          yield* writeGenesis(
+            genesis,
+            yield* Effect.forEach(signers, (signer) => signGenesis(genesis, signer)),
+          );
+          // A one-root identity is immediately usable. Larger quorums keep
+          // roots offline and add devices explicitly with `id rotate`.
+          if (threshold === 1) {
+            const payload = yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(first.publicKey),
+              capabilities: ["source.push", "social.write"],
+              id: Log.newId(),
+            });
+            const commit = yield* Log.issue(payload, signers);
+            yield* confirm(genesis, commit);
+          }
+        }),
+      );
+      const encoded = encodePrincipal({ id: principalId(genesis.repoId) });
+      yield* Console.log(`PrincipalID: ${genesis.repoId}`);
+      if (Result.isSuccess(encoded)) yield* Console.log(`Shareable: ${encoded.success}`);
+    }),
+);
+
+const rotate = Command.make(
+  "rotate",
+  {
+    root: rootFlag,
+    rootKey: rootKeys,
+    newKey: Flag.string("new-key").pipe(
+      Flag.withDescription("Path to the new device's SSH public key"),
+    ),
+    old: Flag.string("revoke").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Old device fingerprint to revoke after granting the new one"),
+    ),
+    repo: repoArgument,
+  },
+  ({ newKey, old, repo, root, rootKey }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const genesis = yield* enabled(repo);
+        const signers = yield* Effect.forEach(rootKey, readPrivateKey);
+        const payload = yield* Certificate.grant({
+          repo: genesis.repoId,
+          publicKey: yield* readPublicKey(newKey),
+          capabilities: ["source.push", "social.write"],
+          id: Log.newId(),
+        });
+        const granted = yield* Log.issue(payload, signers);
+        yield* confirm(genesis, granted);
+        if (old !== "") {
+          if (!isFingerprint(old)) {
+            return yield* new Invalid({ field: "revoke", reason: `'${old}' is not a fingerprint` });
+          }
+          const revoked = yield* Log.issue(
+            Certificate.revoke({
+              repo: genesis.repoId,
+              subject: old,
+              reason: "rotated",
+              id: Log.newId(),
+            }),
+            signers,
+          );
+          yield* confirm(genesis, revoked);
+        }
+        yield* Console.log(`Current device: ${payload.subject}`);
+        if (old !== "") yield* Console.log(`Revoked old device: ${old}`);
+      }),
+    ),
+);
+
+const revoke = Command.make(
+  "revoke",
+  {
+    root: rootFlag,
+    rootKey: rootKeys,
+    subject: Flag.string("subject").pipe(Flag.withDescription("Device key fingerprint")),
+    reason: Flag.choice("reason", ["rotated", "left", "compromised", "superseded"]).pipe(
+      Flag.withDefault("compromised"),
+    ),
+    repo: repoArgument,
+  },
+  ({ reason, repo, root, rootKey, subject }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const genesis = yield* enabled(repo);
+        const signers = yield* Effect.forEach(rootKey, readPrivateKey);
+        if (!isFingerprint(subject)) {
+          return yield* new Invalid({
+            field: "subject",
+            reason: `'${subject}' is not a fingerprint`,
+          });
+        }
+        const commit = yield* Log.issue(
+          Certificate.revoke({ repo: genesis.repoId, subject, reason, id: Log.newId() }),
+          signers,
+        );
+        const projection = yield* confirm(genesis, commit);
+        const revoked = openWindow(projection.revoked.get(subject) ?? []);
+        if (revoked === null) {
+          return yield* new Invalid({ field: "subject", reason: `${subject} was not revoked` });
+        }
+        yield* Console.log(`Revoked ${subject} (${reason})`);
+      }),
+    ),
+);
+
+const status = Command.make("status", { root: rootFlag, repo: repoArgument }, ({ repo, root }) =>
+  withRepo(
+    root,
+    repo,
+    Effect.gen(function* () {
+      const genesis = yield* enabled(repo);
+      const projection = yield* project(genesis);
+      yield* Console.log(`PrincipalID: ${genesis.repoId}`);
+      yield* Console.log(`Trust head: ${projection.head ?? "empty"}`);
+      for (const member of projection.members.values()) {
+        yield* Console.log(`  ${member.fingerprint}  ${member.capabilities.join(",")}`);
+      }
+      for (const windows of projection.revoked.values()) {
+        const revoked = openWindow(windows);
+        if (revoked !== null)
+          yield* Console.log(`  ${revoked.subject}  revoked (${revoked.reason})`);
+      }
+    }),
+  ),
+);
+
+export const idCommand = Command.make("id", {}, () =>
+  Console.log("git+ id <init|rotate|revoke|status> — see --help"),
+).pipe(
+  Command.withSubcommands([
+    init.pipe(Command.withDescription("Create a stable PrincipalID repository")),
+    rotate.pipe(Command.withDescription("Grant a new device, then optionally revoke the old one")),
+    revoke.pipe(Command.withDescription("Revoke an identity device key")),
+    status.pipe(Command.withDescription("Show the PrincipalID and current devices")),
+  ]),
+);

--- a/src/cli/inbox.node.ts
+++ b/src/cli/inbox.node.ts
@@ -1,0 +1,37 @@
+/** Stock-Git transport for the deliberately unauthenticated inbox door. */
+import { execFile } from "node:child_process";
+
+import { Effect } from "effect";
+
+import { Invalid } from "../git/Error.ts";
+
+export const pushInbox = Effect.fn("cli.inbox.push")(function* (input: {
+  readonly url: string;
+  readonly head: string;
+  readonly id: string;
+}) {
+  const destination = `refs/quarantine/inbox/${input.id}`;
+  yield* Effect.tryPromise({
+    try: () =>
+      new Promise<void>((resolve, reject) => {
+        execFile(
+          "git",
+          [
+            "-c",
+            "http.extraHeader=Git-Inbox: 1",
+            "push",
+            input.url,
+            `${input.head}:${destination}`,
+          ],
+          { env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+          (error) => (error === null ? resolve() : reject(error)),
+        );
+      }),
+    catch: (cause) =>
+      new Invalid({
+        field: "inbox",
+        reason: cause instanceof Error ? cause.message : String(cause),
+      }),
+  });
+  return destination;
+});

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -76,6 +76,12 @@ const seed = (directory: string, message: string) =>
   );
 
 describe("cli", () => {
+  it("exposes identity and social-web command groups", async () => {
+    const help = await cli(["--help"]);
+    assert.match(help, /\bid\b.*Stable principal identity/s);
+    assert.match(help, /\bsocial\b.*Social graph/s);
+  });
+
   it("init, refs and log against a seeded repository", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "cli-basic-"));
     try {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -48,6 +48,7 @@ import * as Static from "../server/Static.ts";
 import { mintDelegation } from "../server/Auth.ts";
 import { readGenesis } from "../trust/Genesis.ts";
 import { hubCommand } from "./hub.ts";
+import { idCommand } from "./id.ts";
 import * as replay from "./replay.ts";
 import {
   cliSignature,
@@ -60,6 +61,7 @@ import {
   withRepo,
 } from "./shared.ts";
 import { sessionCommand } from "./session.ts";
+import { socialCommand } from "./social.ts";
 import { taskCommand } from "./task.ts";
 import { prCommand } from "./pr.ts";
 import { wakeCommand } from "./wake.ts";
@@ -1183,6 +1185,7 @@ const git = Command.make("git+").pipe(
     gc.pipe(Command.withDescription("Drop unreachable objects, optionally repacking")),
     grep.pipe(Command.withDescription("Search a revision's file contents")),
     hubCommand.pipe(Command.withDescription("Repository identity, membership and trust")),
+    idCommand.pipe(Command.withDescription("Stable principal identity and device rotation")),
     history.pipe(Command.withDescription("Commits that changed one path")),
     init.pipe(Command.withDescription("Create an empty bare repository")),
     log.pipe(Command.withDescription("Commit history, newest first")),
@@ -1213,6 +1216,7 @@ const git = Command.make("git+").pipe(
     sessionCommand.pipe(
       Command.withDescription("Record what an agent was told, and what came of it"),
     ),
+    socialCommand.pipe(Command.withDescription("Social graph: follows, vouches and discovery")),
     tag.pipe(Command.withDescription("List, create or delete tags")),
     taskCommand.pipe(Command.withDescription("What needs doing, and who is on it")),
     wakeCommand,

--- a/src/cli/pr.ts
+++ b/src/cli/pr.ts
@@ -484,6 +484,7 @@ const show = Command.make(
             ...state,
             claims: undefined,
             openers: [...state.openers],
+            openerPrincipals: [...state.openerPrincipals],
             redacted: [...state.redacted],
           },
           null,

--- a/src/cli/remote-id.node.ts
+++ b/src/cli/remote-id.node.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/** Verify a typed repository identity, pin it, then delegate to stock Git. */
+import { execFile, spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { Effect, Predicate, Result } from "effect";
+
+import { Invalid } from "../git/Error.ts";
+import { decodeIdentifier } from "../social/Encode.ts";
+import { load as loadGenesis, type RepoId } from "../trust/Genesis.ts";
+import { canonicalUrl, KnownRepos } from "../trust/KnownRepos.ts";
+import { layer as knownRepos } from "../trust/KnownRepos.node.ts";
+import { identifierFromUrl, resolveLocation } from "./remote-id.ts";
+
+const cleanGitEnvironment = (): NodeJS.ProcessEnv => {
+  const environment = { ...process.env };
+  // A remote helper inherits the caller's repository variables. They must not
+  // redirect the isolated preflight fetch into the clone that invoked us.
+  for (const name of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_PREFIX",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_INDEX_FILE",
+  ]) {
+    delete environment[name];
+  }
+  environment["GIT_TERMINAL_PROMPT"] = "0";
+  return environment;
+};
+
+const git = (directory: string, arguments_: ReadonlyArray<string>): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    execFile(
+      "git",
+      [...arguments_],
+      {
+        cwd: directory,
+        encoding: null,
+        env: cleanGitEnvironment(),
+        maxBuffer: 4 * 1024 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error !== null) {
+          const detail = stderr.toString("utf8").trim();
+          reject(new Error(detail === "" ? error.message : detail));
+          return;
+        }
+        resolve(new Uint8Array(stdout));
+      },
+    );
+  });
+
+/** Fetch only the advertised genesis record and compute its identity. */
+export const identityAt = async (url: string): Promise<RepoId> => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "git-id-"));
+  try {
+    await git(directory, ["init", "--bare", "--quiet", "."]);
+    await git(directory, [
+      "-c",
+      "protocol.version=2",
+      "fetch",
+      "--quiet",
+      "--no-tags",
+      "--depth=1",
+      url,
+      "refs/meta/trust/genesis",
+    ]);
+    const bytes = await git(directory, ["show", "FETCH_HEAD:genesis.json"]);
+    return (await Effect.runPromise(loadGenesis(bytes))).repoId;
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+};
+
+const locateAndPin = (source: string) =>
+  Effect.gen(function* () {
+    const encoded = identifierFromUrl(source);
+    if (encoded === null) {
+      return yield* new Invalid({ field: "url", reason: `'${source}' is not a git+id URL` });
+    }
+    const decoded = decodeIdentifier(encoded);
+    if (Result.isFailure(decoded)) return yield* decoded.failure;
+    if (decoded.success.kind !== "repository") {
+      return yield* new Invalid({
+        field: "identifier",
+        reason: "a PrincipalID cannot be used as a repository clone URL",
+      });
+    }
+
+    const store = yield* KnownRepos;
+    const known = yield* store.list;
+    const resolved = resolveLocation(encoded, known);
+    if (Result.isFailure(resolved)) return yield* resolved.failure;
+
+    const presented = yield* Effect.tryPromise({
+      try: () => identityAt(resolved.success),
+      catch: (cause) =>
+        new Invalid({
+          field: "identifier",
+          reason: `could not verify ${resolved.success}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        }),
+    });
+    if (presented !== decoded.success.id) {
+      return yield* new Invalid({
+        field: "identifier",
+        reason: `bootstrap location presented ${presented}, expected ${decoded.success.id}`,
+      });
+    }
+
+    const url = yield* canonicalUrl(resolved.success);
+    const existing = known.find((entry) => entry.repoId === presented && entry.url === url);
+    yield* store.remember({
+      url,
+      repoId: presented,
+      provenance: existing?.provenance ?? { kind: "tofu" },
+    });
+    // Keep credentials present on this invocation out of `known_repos`, but
+    // do not strip them from the delegate that still needs to perform clone.
+    return resolved.success;
+  }).pipe(Effect.provide(knownRepos));
+
+const delegate = (name: string, url: string): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const child = spawn("git", ["remote-http", name, url], { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve(signal === null ? (code ?? 1) : 128));
+  });
+
+export const run = async (): Promise<void> => {
+  const name = process.argv[2];
+  const source = process.argv[3];
+  if (name === undefined || source === undefined) {
+    process.stderr.write("usage: git-remote-git+id <name> <git+id://grepo1…>\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const location = await Effect.runPromise(locateAndPin(source));
+    process.exitCode = await delegate(name, location);
+  } catch (error) {
+    const reason =
+      Predicate.hasProperty(error, "reason") && Predicate.isString(error.reason)
+        ? error.reason
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    process.stderr.write(`git+id: ${reason}\n`);
+    process.exitCode = 1;
+  }
+};
+
+if (import.meta.main) void run();

--- a/src/cli/remote-id.test.ts
+++ b/src/cli/remote-id.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer, Result } from "effect";
+
+import { stores } from "../git/Node.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import { serve, type Server } from "../host/Node.ts";
+import { encodePrincipal, encodeRepository } from "../social/Encode.ts";
+import { hasGit, gitEnv } from "../testing/Git.ts";
+import { enableHubUnder } from "../testing/Hub.ts";
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId } from "../trust/Principal.ts";
+import { identifierFromUrl, resolveLocation } from "./remote-id.ts";
+
+/** SAFETY: canonical 32-byte digest spelling for identifier tests. */
+const repo = (seed: string): RepoId => `SHA256:${seed.repeat(42).slice(0, 42)}A` as RepoId;
+
+const value = <A, E>(result: Result.Result<A, E>): A => {
+  assert.ok(Result.isSuccess(result));
+  return result.success;
+};
+
+const execFileAsync = promisify(execFile);
+const author = {
+  name: "Alice",
+  email: "alice@example.com",
+  at: new Date("2026-08-20T00:00:00Z"),
+  offset: 0,
+};
+
+const shellQuote = (value: string): string => `'${value.replaceAll("'", `'"'"'`)}'`;
+
+describe("git+id remote helper", () => {
+  it.effect("prefers a pinned location and otherwise uses an embedded bootstrap hint", () =>
+    Effect.sync(() => {
+      const id = repo("a");
+      const encoded = value(
+        encodeRepository({ id, hints: ["https://bootstrap.example/acme/project"] }),
+      );
+
+      assert.equal(identifierFromUrl(`git+id://${encoded}`), encoded);
+      assert.equal(value(resolveLocation(encoded, [])), "https://bootstrap.example/acme/project");
+      assert.equal(
+        value(resolveLocation(encoded, [{ url: "https://pinned.example/project", repoId: id }])),
+        "https://pinned.example/project",
+      );
+    }),
+  );
+
+  it.effect("refuses to use a PrincipalID where a repository identity is required", () =>
+    Effect.sync(() => {
+      const encoded = value(encodePrincipal({ id: principalId(repo("b")) }));
+      const resolved = resolveLocation(encoded, []);
+      assert.ok(Result.isFailure(resolved));
+      assert.match(resolved.failure.reason, /PrincipalID/);
+    }),
+  );
+
+  describe.skipIf(!hasGit)("stock Git interoperability", () => {
+    it.live("preflights the genesis pin before delegating a clone", () =>
+      Effect.promise(async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), "git-id-interop-"));
+        let server: Server | null = null;
+        try {
+          const fixture = await enableHubUnder(root, "project", ["source.push"]);
+          const revision = await Effect.runPromise(
+            Effect.gen(function* () {
+              const repository = yield* Repository;
+              const blob = yield* repository.writeBlob(new TextEncoder().encode("pinned\n"));
+              const tree = yield* repository.writeTree([
+                { mode: "100644", name: "identity.txt", oid: blob },
+              ]);
+              return yield* repository.commit({ branch: "main", tree, message: "seed", author });
+            }).pipe(
+              Effect.provide(
+                GitRepository.layer.pipe(
+                  Layer.provide(GitRepository.hooksNoop),
+                  Layer.provide(stores(path.join(root, "project"))),
+                ),
+              ),
+            ),
+          );
+
+          server = await serve({ root });
+          const hint = `${server.url}/project`;
+          const encoded = value(encodeRepository({ id: fixture.repoId, hints: [hint] }));
+
+          const executableDirectory = path.join(root, "bin");
+          const config = path.join(root, "config");
+          await fs.mkdir(executableDirectory);
+          const helper = path.join(executableDirectory, "git-remote-git+id");
+          await fs.writeFile(
+            helper,
+            [
+              "#!/bin/sh",
+              `exec ${shellQuote(process.execPath)} ${shellQuote(path.join(import.meta.dirname, "remote-id.node.ts"))} "$@"`,
+              "",
+            ].join("\n"),
+            { mode: 0o755 },
+          );
+          const environment = {
+            ...gitEnv,
+            PATH: `${executableDirectory}${path.delimiter}${process.env["PATH"] ?? ""}`,
+            XDG_CONFIG_HOME: config,
+            GIT_TERMINAL_PROMPT: "0",
+          };
+
+          const destination = path.join(root, "clone");
+          await execFileAsync("git", ["clone", "--quiet", `git+id://${encoded}`, destination], {
+            cwd: root,
+            env: environment,
+            encoding: "utf8",
+          });
+          const cloned = await execFileAsync("git", ["-C", destination, "rev-parse", "HEAD"], {
+            cwd: root,
+            env: environment,
+            encoding: "utf8",
+          });
+          assert.equal(cloned.stdout.trim(), revision);
+          assert.equal(
+            await fs.readFile(path.join(destination, "identity.txt"), "utf8"),
+            "pinned\n",
+          );
+
+          const knownRepos = path.join(config, "chr33s-git", "known_repos");
+          const pinned = await fs.readFile(knownRepos, "utf8");
+          assert.match(pinned, new RegExp(fixture.repoId.replace(/[+/]/g, "\\$&")));
+
+          const wrong = repo("z");
+          const mismatched = value(encodeRepository({ id: wrong, hints: [hint] }));
+          const refused = await execFileAsync(
+            "git",
+            ["clone", "--quiet", `git+id://${mismatched}`, path.join(root, "mismatch")],
+            { cwd: root, env: environment, encoding: "utf8" },
+          ).then(
+            () => "",
+            (cause: unknown) => String(cause),
+          );
+          assert.match(refused, /presented .* expected/);
+          assert.equal((await fs.readFile(knownRepos, "utf8")).includes(wrong), false);
+        } finally {
+          if (server !== null) await server.close();
+          await fs.rm(root, { recursive: true, force: true });
+        }
+      }),
+    );
+  });
+});

--- a/src/cli/remote-id.ts
+++ b/src/cli/remote-id.ts
@@ -1,0 +1,49 @@
+/** Pure resolution for `git+id://grepo1…`; the Node delegate lives beside it. */
+import { Result } from "effect";
+
+import { Invalid } from "../git/Error.ts";
+import { decodeIdentifier } from "../social/Encode.ts";
+import type { KnownRepo } from "../trust/KnownRepos.ts";
+
+export const identifierFromUrl = (url: string): string | null => {
+  const prefix = "git+id://";
+  if (!url.toLowerCase().startsWith(prefix)) return null;
+  const body = url.slice(prefix.length).replace(/^\/+/, "");
+  const end = body.search(/[/?#]/);
+  const encoded = end === -1 ? body : body.slice(0, end);
+  if (encoded === "") return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
+};
+
+/** A previously pinned URL wins; embedded hints are bootstrap locations only. */
+export const resolveLocation = (
+  encoded: string,
+  known: ReadonlyArray<KnownRepo>,
+): Result.Result<string, Invalid> => {
+  const decoded = decodeIdentifier(encoded);
+  if (Result.isFailure(decoded)) return Result.fail(decoded.failure);
+  if (decoded.success.kind !== "repository") {
+    return Result.fail(
+      new Invalid({
+        field: "identifier",
+        reason: "a PrincipalID cannot be used as a repository clone URL",
+      }),
+    );
+  }
+
+  const pinned = known.find((entry) => entry.repoId === decoded.success.id);
+  if (pinned !== undefined) return Result.succeed(pinned.url);
+  const hint = decoded.success.hints[0];
+  return hint === undefined
+    ? Result.fail(
+        new Invalid({
+          field: "identifier",
+          reason: `${decoded.success.id} has no known location or embedded hint`,
+        }),
+      )
+    : Result.succeed(hint);
+};

--- a/src/cli/social.ts
+++ b/src/cli/social.ts
@@ -1,0 +1,637 @@
+/** Commands that publish and query one principal's signed social log. */
+import { Console, Effect, Result } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+
+import { fingerprint, parsePublicKey } from "../crypto/SshSignature.ts";
+import { Invalid } from "../git/Error.ts";
+import { Repository } from "../git/Repository.ts";
+import * as Introduce from "../social/Introduce.ts";
+import * as Inbox from "../social/Inbox.ts";
+import * as Lineage from "../social/Lineage.ts";
+import * as SocialLog from "../social/Log.ts";
+import * as SocialProjection from "../social/Projection.ts";
+import * as Statement from "../social/Statement.ts";
+import * as Sync from "../social/Sync.node.ts";
+import { localSocialWeb } from "../social/Web.node.ts";
+import { isRepoId, readGenesis, type RepoId } from "../trust/Genesis.ts";
+import { KnownRepos } from "../trust/KnownRepos.ts";
+import { layer as knownRepos } from "../trust/KnownRepos.node.ts";
+import { isPrincipalId, principalId, principalOf, type PrincipalId } from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import * as Verify from "../trust/Verify.ts";
+import { pushInbox } from "./inbox.node.ts";
+import {
+  mustResolve,
+  readPrivateKey,
+  readPublicKey,
+  repoArgument,
+  rootFlag,
+  withRepo,
+} from "./shared.ts";
+
+const keyFlag = Flag.string("key").pipe(
+  Flag.withDescription("Path to the identity device private key"),
+);
+
+const principal = (value: string): Effect.Effect<PrincipalId, Invalid> =>
+  isPrincipalId(value)
+    ? Effect.succeed(value)
+    : Effect.fail(new Invalid({ field: "principal", reason: `'${value}' is not a PrincipalID` }));
+
+const repositoryId = (value: string): Effect.Effect<RepoId, Invalid> =>
+  isRepoId(value)
+    ? Effect.succeed(value)
+    : Effect.fail(new Invalid({ field: "repo", reason: `'${value}' is not a RepoID` }));
+
+const identity = Effect.fn("cli.social.identity")(function* (repo: string) {
+  const repository = yield* Repository;
+  const stored = yield* readGenesis();
+  if (stored === null) {
+    return yield* new Invalid({ field: "repo", reason: `${repo} is not an identity repository` });
+  }
+  const trust = yield* projectTrust(stored.genesis);
+  const author = principalId(stored.genesis.repoId);
+  return {
+    genesis: stored.genesis,
+    trust,
+    author,
+    context: {
+      author,
+      id: SocialLog.newId(),
+      socialHead: yield* repository.resolve(SocialLog.LOG_REF),
+      trustHead: trust.head,
+    },
+  };
+});
+
+const publish = Effect.fn("cli.social.publish")(function* (
+  repo: string,
+  payload: Statement.SocialStatement,
+  key: string,
+) {
+  const signer = yield* readPrivateKey(key);
+  const current = yield* identity(repo);
+  const print = yield* fingerprint(signer.publicKey);
+  const authorization = yield* Verify.authorizeKey({
+    projection: current.trust,
+    signer: print,
+    capability: "social.write",
+  });
+  if (!authorization.ok) {
+    return yield* new Invalid({ field: "authorization", reason: authorization.reason });
+  }
+  const commit = yield* SocialLog.issue(payload, signer);
+  const verified = yield* SocialLog.verified(current.genesis, current.trust);
+  const refusal = verified.rejected.find((entry) => entry.commit === commit);
+  if (refusal !== undefined) {
+    return yield* new Invalid({ field: "social", reason: refusal.reason });
+  }
+  if (!verified.statements.some((entry) => entry.commit === commit)) {
+    return yield* new Invalid({
+      field: "social",
+      reason: `${commit} did not enter the projection`,
+    });
+  }
+  yield* Console.log(`${payload.type} ${payload.id}`);
+  yield* Console.log(`  ${commit}`);
+});
+
+const follow = Command.make(
+  "follow",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    petname: Flag.string("name").pipe(Flag.withDescription("Your local name for this principal")),
+    subject: Argument.string("principal"),
+    repo: repoArgument,
+  },
+  ({ key, petname, repo, root, subject }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(
+          repo,
+          Statement.follow({
+            ...current.context,
+            subject: yield* principal(subject),
+            petname,
+          }),
+          key,
+        );
+      }),
+    ),
+);
+
+const vouch = Command.make(
+  "vouch",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    scope: Flag.string("scope").pipe(
+      Flag.withDefault("introduce.repo"),
+      Flag.withDescription("Comma-separated introduce.repo, introduce.key, review, vouch"),
+    ),
+    depth: Flag.integer("depth").pipe(Flag.withDefault(0)),
+    expires: Flag.integer("expires-in").pipe(Flag.withDefault(0)),
+    subject: Argument.string("principal"),
+    repo: repoArgument,
+  },
+  ({ depth, expires, key, repo, root, scope, subject }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        const requested = scope.split(",").map((value) => value.trim());
+        const accepted = requested.filter((value): value is Statement.SocialScope =>
+          Statement.SOCIAL_SCOPES.some((candidate) => candidate === value),
+        );
+        if (accepted.length !== requested.length) {
+          return yield* new Invalid({ field: "scope", reason: `'${scope}' has an unknown scope` });
+        }
+        yield* publish(
+          repo,
+          Statement.vouch({
+            ...current.context,
+            subject: yield* principal(subject),
+            scope: accepted,
+            depth,
+            expiresAt: expires === 0 ? null : new Date(Date.now() + expires * 1000),
+          }),
+          key,
+        );
+      }),
+    ),
+);
+
+const attest = Command.make(
+  "attest",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    url: Flag.string("url").pipe(
+      Flag.withDescription("Repository URL (repeat for mirrors)"),
+      Flag.atLeast(1),
+    ),
+    role: Flag.choice("role", ["origin", "mirror", "fork"]).pipe(Flag.withDefault("origin")),
+    forkOf: Flag.string("fork-of").pipe(Flag.withDefault("")),
+    lineage: Flag.string("lineage").pipe(Flag.withDefault("")),
+    inbox: Flag.string("inbox").pipe(Flag.withDefault("")),
+    target: Argument.string("RepoID"),
+    repo: repoArgument,
+  },
+  ({ forkOf, inbox, key, lineage, repo, role, root, target, url }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(
+          repo,
+          Statement.attestRepo({
+            ...current.context,
+            repo: yield* repositoryId(target),
+            urls: url,
+            role,
+            forkOf: forkOf === "" ? null : yield* repositoryId(forkOf),
+            lineage: lineage === "" ? null : lineage,
+            inbox: inbox === "" ? null : inbox,
+          }),
+          key,
+        );
+      }),
+    ),
+);
+
+const attestPrincipal = Command.make(
+  "attest-principal",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    publicKey: Flag.string("public-key").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Path to the subject's SSH public key"),
+    ),
+    externalIdentity: Flag.string("identity").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("External platform identity, for example github:alice"),
+    ),
+    proof: Flag.string("proof").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Bidirectional proof URL for --identity"),
+    ),
+    subject: Argument.string("PrincipalID"),
+    repo: repoArgument,
+  },
+  ({ externalIdentity, key, proof, publicKey, repo, root, subject }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        const target = yield* principal(subject);
+        if (publicKey !== "" && externalIdentity === "" && proof === "") {
+          yield* publish(
+            repo,
+            Statement.attestPrincipalKey({
+              ...current.context,
+              subject: target,
+              publicKey: yield* readPublicKey(publicKey),
+            }),
+            key,
+          );
+          return;
+        }
+        if (publicKey === "" && externalIdentity !== "" && proof !== "") {
+          yield* publish(
+            repo,
+            Statement.attestExternalIdentity({
+              ...current.context,
+              subject: target,
+              identity: externalIdentity,
+              proof,
+            }),
+            key,
+          );
+          return;
+        }
+        return yield* new Invalid({
+          field: "attestation",
+          reason: "provide either --public-key, or both --identity and --proof",
+        });
+      }),
+    ),
+);
+
+const publishMirrors = Command.make(
+  "publish-mirrors",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    url: Flag.string("url").pipe(Flag.atLeast(1)),
+    mode: Flag.choice("mode", ["read", "write"]).pipe(Flag.withDefault("read")),
+    target: Argument.string("repo-or-self"),
+    repo: repoArgument,
+  },
+  ({ key, mode, repo, root, target, url }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(
+          repo,
+          Statement.mirrors({
+            ...current.context,
+            repo: target === "self" ? "self" : yield* repositoryId(target),
+            urls: url.map((location) => ({ url: location, mode })),
+          }),
+          key,
+        );
+      }),
+    ),
+);
+
+const label = Command.make(
+  "label",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    namespace: Flag.string("namespace"),
+    value: Flag.string("label"),
+    subject: Argument.string("subject"),
+    repo: repoArgument,
+  },
+  ({ key, namespace, repo, root, subject, value }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(
+          repo,
+          Statement.label({ ...current.context, subject, namespace, label: value }),
+          key,
+        );
+      }),
+    ),
+);
+
+const revoke = Command.make(
+  "revoke",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    reason: Flag.choice("reason", ["withdrawn", "superseded", "compromised"]).pipe(
+      Flag.withDefault("withdrawn"),
+    ),
+    target: Argument.string("statement-id"),
+    repo: repoArgument,
+  },
+  ({ key, reason, repo, root, target }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(repo, Statement.revoke({ ...current.context, target, reason }), key);
+      }),
+    ),
+);
+
+const checkpoint = Command.make(
+  "checkpoint",
+  { root: rootFlag, key: keyFlag, repo: repoArgument },
+  ({ key, repo, root }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        yield* publish(
+          repo,
+          Statement.checkpoint({
+            ...current.context,
+            frontier: current.context.socialHead === null ? [] : [current.context.socialHead],
+          }),
+          key,
+        );
+      }),
+    ),
+);
+
+const lineage = Command.make(
+  "lineage",
+  {
+    root: rootFlag,
+    revision: Flag.string("revision").pipe(Flag.withDefault("HEAD")),
+    upstream: Flag.string("from").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Upstream revision; omit to compute an origin's root lineage"),
+    ),
+    repo: repoArgument,
+  },
+  ({ repo, revision, root, upstream }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const repository = yield* Repository;
+        const head = yield* mustResolve(repository, revision);
+        const from = upstream === "" ? undefined : yield* mustResolve(repository, upstream);
+        const computed =
+          from === undefined
+            ? yield* Lineage.earliestUnique({ head })
+            : yield* Lineage.earliestUnique({ head, upstream: from });
+        yield* Console.log(computed);
+      }),
+    ),
+);
+
+const graphOf = Effect.fn("cli.social.graphOf")(function* (repo: string) {
+  const current = yield* identity(repo);
+  const log = yield* SocialLog.verified(current.genesis, current.trust);
+  const web = yield* Effect.serviceOption(SocialProjection.SocialWeb);
+  const held = web._tag === "Some" ? yield* web.value.logs : [log];
+  const logs = new Map(
+    [...held, log].map((candidate) => [`${candidate.principal}\u0000${candidate.head}`, candidate]),
+  );
+  return {
+    current,
+    log,
+    graph: SocialProjection.project({ roots: [current.author], logs: [...logs.values()] }),
+  };
+});
+
+const find = Command.make(
+  "find",
+  { root: rootFlag, query: Argument.string("name-or-RepoID"), repo: repoArgument },
+  ({ query, repo, root }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const { current, graph } = yield* graphOf(repo).pipe(Effect.provide(localSocialWeb(root)));
+        let wanted = isRepoId(query) ? query : null;
+        if (wanted === null) {
+          for (const [subject, name] of graph.petnames.get(current.author) ?? []) {
+            if (name === query) {
+              wanted = subject;
+              break;
+            }
+          }
+        }
+        const found = Introduce.repositories(graph).filter(
+          (entry) => wanted === null || entry.repo === wanted || entry.url.includes(query),
+        );
+        for (const entry of found) {
+          yield* Console.log(
+            `${entry.repo}\t${entry.role}\t${entry.url}\t${entry.paths.length} path(s)`,
+          );
+        }
+      }),
+    ),
+);
+
+const mirrors = Command.make(
+  "mirrors",
+  { root: rootFlag, target: Argument.string("repo-or-self"), repo: repoArgument },
+  ({ repo, root, target }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const { graph } = yield* graphOf(repo).pipe(Effect.provide(localSocialWeb(root)));
+        for (const entry of graph.active) {
+          if (entry.payload.type !== "social.mirrors" || entry.payload.repo !== target) continue;
+          for (const mirror of entry.payload.urls) {
+            yield* Console.log(`${mirror.mode}\t${mirror.url}\t${entry.payload.author}`);
+          }
+        }
+      }),
+    ),
+);
+
+const who = Command.make(
+  "who",
+  { root: rootFlag, key: Argument.string("fingerprint"), repo: repoArgument },
+  ({ key, repo, root }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const { graph } = yield* graphOf(repo).pipe(Effect.provide(localSocialWeb(root)));
+        for (const entry of graph.active) {
+          if (
+            entry.payload.type !== "social.attest.principal" ||
+            entry.payload.claim !== "key-of" ||
+            entry.payload.publicKey === undefined
+          ) {
+            continue;
+          }
+          const parsed = parsePublicKey(entry.payload.publicKey);
+          if (Result.isFailure(parsed) || (yield* fingerprint(parsed.success)) !== key) continue;
+          const subject = principalOf(entry.payload.subject);
+          if (subject !== null)
+            yield* Console.log(`${subject}\tattested by ${entry.payload.author}`);
+        }
+      }),
+    ),
+);
+
+const sync = Command.make(
+  "sync",
+  {
+    root: rootFlag,
+    depth: Flag.integer("depth").pipe(
+      Flag.withDefault(1),
+      Flag.withDescription("Follow depth to synchronize (1-16)"),
+    ),
+    token: Flag.string("token").pipe(
+      Flag.withDefault(""),
+      Flag.withDescription("Credential shared by identity mirrors that require one"),
+    ),
+    repo: repoArgument,
+  },
+  ({ depth, repo, root, token }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        if (depth < 1 || depth > 16) {
+          return yield* new Invalid({ field: "depth", reason: "sync depth must be from 1 to 16" });
+        }
+        const current = yield* identity(repo);
+        const known = yield* KnownRepos;
+        const pins = yield* known.list;
+        const visited = new Set<PrincipalId>([current.author]);
+        let frontier = new Set<PrincipalId>([current.author]);
+        let synchronized = 0;
+
+        for (let hop = 0; hop < depth && frontier.size > 0; hop++) {
+          const { graph } = yield* graphOf(repo);
+          const next = new Set<PrincipalId>();
+          for (const subject of Sync.followedBy(graph, frontier)) {
+            if (visited.has(subject)) continue;
+            visited.add(subject);
+            next.add(subject);
+            const location = Sync.locationOf(graph, subject, pins);
+            if (location === null) {
+              yield* Console.error(`! ${subject}: no pinned, mirrored, or attested location`);
+              continue;
+            }
+            const outcome = yield* Sync.syncIdentity({
+              root,
+              principal: subject,
+              url: location,
+              token: token === "" ? undefined : token,
+            });
+            synchronized++;
+            yield* Console.log(
+              `${subject}\t${location}\t${outcome.fetched.length} fetched, ${outcome.joined.length} joined`,
+            );
+          }
+          frontier = next;
+        }
+        yield* Console.log(`${synchronized} followed identity repo(s) synchronized`);
+      }).pipe(Effect.provide(localSocialWeb(root)), Effect.provide(knownRepos)),
+    ),
+);
+
+const status = Command.make("status", { root: rootFlag, repo: repoArgument }, ({ repo, root }) =>
+  withRepo(
+    root,
+    repo,
+    Effect.gen(function* () {
+      const { graph, log } = yield* graphOf(repo).pipe(Effect.provide(localSocialWeb(root)));
+      yield* Console.log(`${log.principal}`);
+      yield* Console.log(`  ${graph.active.length} active statement(s) at ${log.head ?? "empty"}`);
+      for (const rejected of [...log.rejected, ...graph.rejected]) {
+        yield* Console.error(`! ${rejected.commit}: ${rejected.reason}`);
+      }
+    }),
+  ),
+);
+
+const inboxList = Command.make(
+  "inbox-list",
+  { root: rootFlag, repo: repoArgument },
+  ({ repo, root }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        for (const proposal of yield* Inbox.pending()) {
+          yield* Console.log(`${proposal.id}\t${proposal.head}\t${proposal.title}`);
+        }
+      }),
+    ),
+);
+
+const inboxSubmit = Command.make(
+  "inbox-submit",
+  {
+    url: Flag.string("url").pipe(Flag.withDescription("Announced repository inbox URL")),
+    id: Flag.string("id").pipe(Flag.withDefault("")),
+    head: Argument.string("revision"),
+  },
+  ({ head, id, url }) =>
+    Effect.gen(function* () {
+      const proposal = id === "" ? SocialLog.newId() : id;
+      const destination = yield* pushInbox({ url, head, id: proposal });
+      yield* Console.log(destination);
+    }),
+);
+
+const inboxAdopt = Command.make(
+  "inbox-adopt",
+  {
+    root: rootFlag,
+    key: keyFlag,
+    proposal: Argument.string("proposal-id"),
+    repo: repoArgument,
+  },
+  ({ key, proposal, repo, root }) =>
+    withRepo(
+      root,
+      repo,
+      Effect.gen(function* () {
+        const current = yield* identity(repo);
+        const opened = yield* Inbox.adopt({
+          genesis: current.genesis,
+          trust: current.trust,
+          proposal,
+          key: yield* readPrivateKey(key),
+        });
+        yield* Console.log(`${opened.pr}\t${opened.commit}`);
+      }),
+    ),
+);
+
+export const socialCommand = Command.make("social", {}, () =>
+  Console.log(
+    "git+ social <follow|vouch|attest|attest-principal|publish-mirrors|label|revoke|checkpoint|lineage|find|mirrors|who|sync|status|inbox-submit|inbox-list|inbox-adopt>",
+  ),
+).pipe(
+  Command.withSubcommands([
+    follow.pipe(Command.withDescription("Follow a principal under a local petname")),
+    vouch.pipe(Command.withDescription("Publish attenuated trust in a principal")),
+    attest.pipe(Command.withDescription("Attest a repository identity and its locations")),
+    attestPrincipal.pipe(Command.withDescription("Attest a principal key or external identity")),
+    publishMirrors.pipe(Command.withDescription("Publish your current mirror locations")),
+    label.pipe(Command.withDescription("Attach a namespaced public label")),
+    revoke.pipe(Command.withDescription("Withdraw an earlier social statement")),
+    checkpoint.pipe(Command.withDescription("Publish a social-log freshness checkpoint")),
+    lineage.pipe(Command.withDescription("Compute an earliest-unique-commit lineage key")),
+    find.pipe(Command.withDescription("Find repositories attested by your rooted web")),
+    mirrors.pipe(Command.withDescription("List attested mirror locations")),
+    who.pipe(Command.withDescription("Resolve key attestations to PrincipalIDs")),
+    sync.pipe(Command.withDescription("Fetch followed identity social logs, bounded by depth")),
+    status.pipe(Command.withDescription("Show this identity's social-log projection")),
+    inboxSubmit.pipe(Command.withDescription("Push a revision through an announced inbox")),
+    inboxList.pipe(Command.withDescription("List quarantined contribution proposals")),
+    inboxAdopt.pipe(Command.withDescription("Adopt a proposal as a signed pull request")),
+  ]),
+);

--- a/src/cli/social.ts
+++ b/src/cli/social.ts
@@ -33,6 +33,14 @@ const keyFlag = Flag.string("key").pipe(
   Flag.withDescription("Path to the identity device private key"),
 );
 
+type SyncTarget =
+  | { readonly subject: PrincipalId; readonly location: null }
+  | {
+      readonly subject: PrincipalId;
+      readonly location: string;
+      readonly outcome: Sync.SyncOutcome;
+    };
+
 const principal = (value: string): Effect.Effect<PrincipalId, Invalid> =>
   isPrincipalId(value)
     ? Effect.succeed(value)
@@ -513,24 +521,37 @@ const sync = Command.make(
         for (let hop = 0; hop < depth && frontier.size > 0; hop++) {
           const { graph } = yield* graphOf(repo);
           const next = new Set<PrincipalId>();
+          const targets: PrincipalId[] = [];
           for (const subject of Sync.followedBy(graph, frontier)) {
             if (visited.has(subject)) continue;
             visited.add(subject);
             next.add(subject);
-            const location = Sync.locationOf(graph, subject, pins);
-            if (location === null) {
-              yield* Console.error(`! ${subject}: no pinned, mirrored, or attested location`);
+            targets.push(subject);
+          }
+          const outcomes = yield* Effect.forEach(
+            targets,
+            (subject) => {
+              const location = Sync.locationOf(graph, subject, pins);
+              if (location === null) return Effect.succeed<SyncTarget>({ subject, location: null });
+              return Sync.syncIdentity({
+                root,
+                principal: subject,
+                url: location,
+                token: token === "" ? undefined : token,
+              }).pipe(Effect.map((outcome): SyncTarget => ({ subject, location, outcome })));
+            },
+            { concurrency: 8 },
+          );
+          for (const outcome of outcomes) {
+            if (outcome.location === null) {
+              yield* Console.error(
+                `! ${outcome.subject}: no pinned, mirrored, or attested location`,
+              );
               continue;
             }
-            const outcome = yield* Sync.syncIdentity({
-              root,
-              principal: subject,
-              url: location,
-              token: token === "" ? undefined : token,
-            });
             synchronized++;
             yield* Console.log(
-              `${subject}\t${location}\t${outcome.fetched.length} fetched, ${outcome.joined.length} joined`,
+              `${outcome.subject}\t${outcome.location}\t${outcome.outcome.fetched.length} fetched, ${outcome.outcome.joined.length} joined`,
             );
           }
           frontier = next;

--- a/src/git/Refspec.test.ts
+++ b/src/git/Refspec.test.ts
@@ -61,6 +61,7 @@ describe("Refspec", () => {
       "the policy ref must be in the hub refspecs",
     );
     assert.notEqual(Refspec.resolve(Refspec.HUB_FETCH, Refspec.TRUST_LOG), null);
+    assert.notEqual(Refspec.resolve(Refspec.HUB_FETCH, Refspec.SOCIAL_LOG), null);
     assert.notEqual(Refspec.resolve(Refspec.HUB_FETCH, "refs/hub/pr/1"), null);
     // And it is hidden from a plain advertisement, so naming it is the only
     // way it ever arrives.
@@ -70,10 +71,13 @@ describe("Refspec", () => {
   it("knows which namespaces only grow, and which are withheld from a clone", () => {
     assert.equal(Refspec.isAppendOnly("refs/hub/pr/1"), true);
     assert.equal(Refspec.isAppendOnly(Refspec.TRUST_LOG), true);
+    assert.equal(Refspec.isAppendOnly(Refspec.SOCIAL_LOG), true);
     assert.equal(Refspec.isAppendOnly("refs/heads/main"), false);
 
     assert.equal(Refspec.hiddenFromAdvertisement("refs/hub/pr/1"), true);
     assert.equal(Refspec.hiddenFromAdvertisement(Refspec.TRUST_LOG), true);
+    assert.equal(Refspec.hiddenFromAdvertisement(Refspec.SOCIAL_LOG), true);
+    assert.equal(Refspec.hiddenFromAdvertisement("refs/quarantine/inbox/1"), true);
     // Identity is never hidden: verifying it would otherwise need permission.
     assert.equal(Refspec.hiddenFromAdvertisement(Refspec.TRUST_GENESIS), false);
     assert.equal(Refspec.hiddenFromAdvertisement("refs/heads/main"), false);
@@ -91,6 +95,9 @@ describe("Refspec", () => {
     assert.equal(Refspec.namesHiddenNamespace("refs/hub/pr/1"), true);
     assert.equal(Refspec.namesHiddenNamespace("refs/meta"), true);
     assert.equal(Refspec.namesHiddenNamespace("refs/meta/trust/"), true);
+    assert.equal(Refspec.namesHiddenNamespace("refs/social"), true);
+    assert.equal(Refspec.namesHiddenNamespace("refs/social/"), true);
+    assert.equal(Refspec.namesHiddenNamespace("refs/quarantine"), true);
 
     // A prefix that merely starts the same way names nothing, and answering it
     // hands `ls-remote 'refs/h*'` the whole namespace for three characters.
@@ -113,9 +120,21 @@ describe("Refspec", () => {
     assert.deepEqual(Refspec.hiddenPrefixes("refs/hub/"), ["refs/hub/"]);
     assert.deepEqual(Refspec.hiddenPrefixes("refs/hub/pr/"), ["refs/hub/pr/"]);
     assert.deepEqual(Refspec.hiddenPrefixes("refs/meta/trust/"), ["refs/meta/trust/"]);
-    // A refspec that covers everything covers both, and has to name both.
-    assert.deepEqual(Refspec.hiddenPrefixes("refs/"), ["refs/hub/", "refs/meta/"]);
-    assert.deepEqual(Refspec.hiddenPrefixes(""), ["refs/hub/", "refs/meta/"]);
+    assert.deepEqual(Refspec.hiddenPrefixes("refs/social/"), ["refs/social/"]);
+    assert.deepEqual(Refspec.hiddenPrefixes("refs/quarantine/"), ["refs/quarantine/"]);
+    // A refspec that covers everything covers all three, and has to name them.
+    assert.deepEqual(Refspec.hiddenPrefixes("refs/"), [
+      "refs/hub/",
+      "refs/meta/",
+      "refs/quarantine/",
+      "refs/social/",
+    ]);
+    assert.deepEqual(Refspec.hiddenPrefixes(""), [
+      "refs/hub/",
+      "refs/meta/",
+      "refs/quarantine/",
+      "refs/social/",
+    ]);
     // And one that covers neither asks for nothing.
     assert.deepEqual(Refspec.hiddenPrefixes("refs/heads/"), []);
     assert.deepEqual(Refspec.hiddenPrefixes("refs/tags/"), []);
@@ -135,7 +154,12 @@ describe("Refspec", () => {
 
     assert.deepEqual(Refspec.probes(spec("refs/hub/*/head:refs/local/*")), ["refs/hub/"]);
     assert.deepEqual(Refspec.probes(spec("refs/hub/*:refs/hub/*")), ["refs/hub/"]);
-    assert.deepEqual(Refspec.probes(spec("refs/*:refs/*")), ["refs/hub/", "refs/meta/"]);
+    assert.deepEqual(Refspec.probes(spec("refs/*:refs/*")), [
+      "refs/hub/",
+      "refs/meta/",
+      "refs/quarantine/",
+      "refs/social/",
+    ]);
     // A source with no wildcard is its own head — and the rules file is
     // hidden from the advertisement too, so it is asked for by name.
     assert.deepEqual(Refspec.probes(spec("refs/meta/policy:refs/meta/policy")), [

--- a/src/git/Refspec.ts
+++ b/src/git/Refspec.ts
@@ -133,6 +133,7 @@ export const DEFAULT_FETCH: ReadonlyArray<Refspec> = [
 export const HUB_FETCH: ReadonlyArray<Refspec> = [
   { force: false, source: "refs/meta/trust/*", destination: "refs/meta/trust/*" },
   { force: false, source: "refs/meta/policy", destination: "refs/meta/policy" },
+  { force: false, source: "refs/social/log", destination: "refs/social/log" },
   { force: false, source: "refs/hub/*", destination: "refs/hub/*" },
 ];
 
@@ -152,11 +153,13 @@ export const HUB_FETCH: ReadonlyArray<Refspec> = [
  * on the object graph, for a ref no fold ever opens.
  */
 export const isAppendOnly = (ref: string): boolean =>
-  ref.startsWith("refs/hub/") || ref === TRUST_LOG;
+  ref.startsWith("refs/hub/") || ref === TRUST_LOG || ref === SOCIAL_LOG;
 
 /** The one trust ref that moves; the genesis never does. */
 export const TRUST_LOG = "refs/meta/trust/log";
 export const TRUST_GENESIS = "refs/meta/trust/genesis";
+/** The one social ref that moves; every statement is a commit in this log. */
+export const SOCIAL_LOG = "refs/social/log";
 
 /**
  * Refs a plain `git clone` should not be sent.
@@ -171,7 +174,11 @@ export const TRUST_GENESIS = "refs/meta/trust/genesis";
  * trusts. Hiding identity would make verification need permission.
  */
 export const hiddenFromAdvertisement = (ref: string): boolean =>
-  ref !== TRUST_GENESIS && (ref.startsWith("refs/hub/") || ref.startsWith("refs/meta/"));
+  ref !== TRUST_GENESIS &&
+  (ref.startsWith("refs/hub/") ||
+    ref.startsWith("refs/meta/") ||
+    ref.startsWith("refs/quarantine/") ||
+    ref.startsWith("refs/social/"));
 
 /**
  * Whether a `ref-prefix` is asking for a hidden namespace.
@@ -194,7 +201,7 @@ export const hiddenFromAdvertisement = (ref: string): boolean =>
 export const namesHiddenNamespace = (prefix: string): boolean =>
   HIDDEN.some((namespace) => prefix.startsWith(namespace) || `${prefix}/` === namespace);
 
-const HIDDEN = ["refs/hub/", "refs/meta/"];
+const HIDDEN = ["refs/hub/", "refs/meta/", "refs/quarantine/", "refs/social/"];
 
 /**
  * The prefixes a client must ask for by name to reach a hidden namespace.

--- a/src/host/Node.ts
+++ b/src/host/Node.ts
@@ -10,6 +10,7 @@
  * per repository name stands in for instance isolation.
  */
 import * as http from "node:http";
+import * as fs from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import * as path from "node:path";
 import { Readable } from "node:stream";
@@ -23,6 +24,11 @@ import { statusOf } from "../git/Error.ts";
 import { stores } from "../git/Node.ts";
 import * as GitRepository from "../git/Repository.ts";
 import type { Repository } from "../git/Repository.ts";
+import * as SocialLog from "../social/Log.ts";
+import { SocialWeb } from "../social/Projection.ts";
+import { readGenesis } from "../trust/Genesis.ts";
+import { Identities, principalId, type PrincipalId } from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
 import * as Api from "../server/Api.ts";
 import * as Auth from "../server/Auth.ts";
 import * as Policy from "../server/Policy.ts";
@@ -86,6 +92,19 @@ export interface Server {
 interface StreamingRequestInit extends RequestInit {
   duplex?: "half";
 }
+
+/** Header dictionary accepted by Node's `ServerResponse.writeHead`. */
+interface NodeHeaders {
+  [name: string]: string;
+}
+
+const nodeHeaders = (headers: Headers): NodeHeaders => {
+  const values: NodeHeaders = {};
+  headers.forEach((value, name) => {
+    values[name] = value;
+  });
+  return values;
+};
 
 export const serve = async (options: ServeOptions): Promise<Server> => {
   const hostname = options.hostname ?? "127.0.0.1";
@@ -185,6 +204,73 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
       Layer.provideMerge(stores(path.join(options.root, repo))),
     );
 
+  /**
+   * Identity repositories and social logs this host already holds.
+   *
+   * A target repository's policy cannot reach through its own `Repository`
+   * service into a sibling repository. The host owns that composition: each
+   * sibling is opened through the same no-hooks layer used by authentication,
+   * verified independently, and only then exposed to the policy fold. Missing
+   * or malformed repositories are absence (and therefore quarantine), never a
+   * reason to take the target repository down.
+   */
+  const localRepositories = Effect.fn("host.Node.localRepositories")(function* () {
+    const entries = yield* Effect.promise(() =>
+      fs.readdir(options.root, { withFileTypes: true }).catch(() => []),
+    );
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+      .slice(0, 4096);
+  });
+
+  const identityAt = Effect.fn("host.Node.identityAt")(function* (wanted: PrincipalId) {
+    for (const name of yield* localRepositories()) {
+      const resolved = yield* Effect.promise(() =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const stored = yield* readGenesis();
+            if (stored === null || principalId(stored.genesis.repoId) !== wanted) return null;
+            const projection = yield* projectTrust(stored.genesis);
+            return { principal: wanted, projection, head: projection.head } as const;
+          }).pipe(
+            Effect.provide(guardLayer(name)),
+            Effect.catch(() => Effect.succeed(null)),
+          ),
+        ),
+      );
+      if (resolved !== null) return resolved;
+    }
+    return null;
+  });
+
+  const localSocialLogs = Effect.fn("host.Node.localSocialLogs")(function* () {
+    const logs: SocialLog.VerifiedLog[] = [];
+    for (const name of yield* localRepositories()) {
+      const verified = yield* Effect.promise(() =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const stored = yield* readGenesis();
+            if (stored === null) return null;
+            const trust = yield* projectTrust(stored.genesis);
+            return yield* SocialLog.verified(stored.genesis, trust);
+          }).pipe(
+            Effect.provide(guardLayer(name)),
+            Effect.catch(() => Effect.succeed(null)),
+          ),
+        ),
+      );
+      if (verified !== null) logs.push(verified);
+    }
+    return logs;
+  });
+
+  const federation = Layer.merge(
+    Layer.succeed(Identities)({ resolve: identityAt }),
+    Layer.succeed(SocialWeb)({ logs: localSocialLogs() }),
+  );
+
   const stateFor = (repo: string): RepoState => {
     const cached = repos.get(repo);
     if (cached !== undefined) {
@@ -263,7 +349,10 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
       layer,
       lfs: lfsFile(path.join(options.root, repo, "lfs")),
       api: (request: Request, requester: Context.Context<Auth.Requester>) =>
-        router.handler(request, requester),
+        // SAFETY: the handler's generated declaration erases its remaining
+        // request-scoped service to `unknown`; this context contains exactly
+        // that `Requester` service and no value is inspected through the cast.
+        router.handler(request, requester as Context.Context<unknown>),
       disposeApi: router.dispose,
       gate: Promise.resolve(),
       delivering: new Set(),
@@ -324,7 +413,7 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
       // consumed as a stream, so nothing that would buffer it may see it first.
       const bulk = await Effect.runPromise(
         CommitPack.handle(request).pipe(
-          Effect.provide(Layer.mergeAll(state.layer, requester, openWrites)),
+          Effect.provide(Layer.mergeAll(state.layer, requester, openWrites, federation)),
         ),
       );
       if (bulk !== null) return bulk;
@@ -339,7 +428,7 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
           Effect.catch((error) =>
             Effect.succeed(Response.json({ _tag: error._tag }, { status: statusOf(error) })),
           ),
-          Effect.provide(Layer.mergeAll(state.layer, requester, openWrites)),
+          Effect.provide(Layer.mergeAll(state.layer, requester, openWrites, federation)),
         ),
       );
       return matched ?? (await state.api(request, asked));
@@ -387,7 +476,7 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
           ? null
           : await assetResponse(options.ui, new Request(url, { method: incoming.method ?? "GET" }));
       if (asset !== null) {
-        outgoing.writeHead(asset.status, Object.fromEntries(asset.headers));
+        outgoing.writeHead(asset.status, nodeHeaders(asset.headers));
         outgoing.end(Buffer.from(await asset.arrayBuffer()));
         return;
       }
@@ -444,7 +533,7 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
       // secret to configure any more, so there is nothing to leave off.
       const denied = await Effect.runPromise(
         Auth.guard(request).pipe(
-          Effect.provide(Layer.mergeAll(guardLayer(repo), nonces, openWrites)),
+          Effect.provide(Layer.mergeAll(guardLayer(repo), nonces, openWrites, federation)),
           // A repository whose identity cannot be read is not a repository
           // with no members: it is one nobody can be checked against, and the
           // honest answer is that the service is unavailable.
@@ -455,7 +544,7 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
         ),
       );
       const deliver = async (response: Response) => {
-        outgoing.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+        outgoing.writeHead(response.status, nodeHeaders(response.headers));
         if (response.body === null) {
           outgoing.end();
         } else {

--- a/src/host/Node.ts
+++ b/src/host/Node.ts
@@ -27,7 +27,12 @@ import type { Repository } from "../git/Repository.ts";
 import * as SocialLog from "../social/Log.ts";
 import { SocialWeb } from "../social/Projection.ts";
 import { readGenesis } from "../trust/Genesis.ts";
-import { Identities, principalId, type PrincipalId } from "../trust/Principal.ts";
+import {
+  Identities,
+  principalId,
+  type PrincipalId,
+  type ResolvedIdentity,
+} from "../trust/Principal.ts";
 import { project as projectTrust } from "../trust/Projection.ts";
 import * as Api from "../server/Api.ts";
 import * as Auth from "../server/Auth.ts";
@@ -225,50 +230,98 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
       .slice(0, 4096);
   });
 
-  const identityAt = Effect.fn("host.Node.identityAt")(function* (wanted: PrincipalId) {
-    for (const name of yield* localRepositories()) {
-      const resolved = yield* Effect.promise(() =>
-        Effect.runPromise(
-          Effect.gen(function* () {
-            const stored = yield* readGenesis();
-            if (stored === null || principalId(stored.genesis.repoId) !== wanted) return null;
-            const projection = yield* projectTrust(stored.genesis);
-            return { principal: wanted, projection, head: projection.head } as const;
-          }).pipe(
-            Effect.provide(guardLayer(name)),
-            Effect.catch(() => Effect.succeed(null)),
-          ),
+  interface FederationSnapshot {
+    readonly identities: ReadonlyMap<PrincipalId, ResolvedIdentity>;
+    readonly logs: ReadonlyArray<SocialLog.VerifiedLog>;
+  }
+
+  /** Read one sibling once; both federation consumers share this result. */
+  const federationEntry = Effect.fn("host.Node.federationEntry")(function* (name: string) {
+    return yield* Effect.promise(() =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const stored = yield* readGenesis();
+          if (stored === null) return null;
+          const projection = yield* projectTrust(stored.genesis);
+          const principal = principalId(stored.genesis.repoId);
+          return {
+            identity: { principal, projection, head: projection.head } satisfies ResolvedIdentity,
+            log: yield* SocialLog.verified(stored.genesis, projection),
+          };
+        }).pipe(
+          Effect.provide(guardLayer(name)),
+          Effect.catch(() => Effect.succeed(null)),
         ),
-      );
-      if (resolved !== null) return resolved;
-    }
-    return null;
+      ),
+    );
   });
 
-  const localSocialLogs = Effect.fn("host.Node.localSocialLogs")(function* () {
+  const loadFederation = Effect.fn("host.Node.loadFederation")(function* () {
+    const entries = yield* Effect.forEach(yield* localRepositories(), federationEntry, {
+      concurrency: 16,
+    });
+    const identities = new Map<PrincipalId, ResolvedIdentity>();
     const logs: SocialLog.VerifiedLog[] = [];
-    for (const name of yield* localRepositories()) {
-      const verified = yield* Effect.promise(() =>
-        Effect.runPromise(
-          Effect.gen(function* () {
-            const stored = yield* readGenesis();
-            if (stored === null) return null;
-            const trust = yield* projectTrust(stored.genesis);
-            return yield* SocialLog.verified(stored.genesis, trust);
-          }).pipe(
-            Effect.provide(guardLayer(name)),
-            Effect.catch(() => Effect.succeed(null)),
-          ),
-        ),
-      );
-      if (verified !== null) logs.push(verified);
+    for (const entry of entries) {
+      if (entry === null) continue;
+      // Preserve the resolver's existing first-directory-wins behavior for a
+      // duplicate identity without dropping either log from the social view.
+      if (!identities.has(entry.identity.principal)) {
+        identities.set(entry.identity.principal, entry.identity);
+      }
+      logs.push(entry.log);
     }
-    return logs;
+    return { identities, logs } satisfies FederationSnapshot;
   });
+
+  let federationEpoch = 0;
+  let cachedFederation: { readonly epoch: number; readonly value: FederationSnapshot } | null =
+    null;
+  let loadingFederation: {
+    readonly epoch: number;
+    readonly value: Promise<FederationSnapshot>;
+  } | null = null;
+
+  /**
+   * One shared, immutable index for all requests until a mutating request
+   * completes. It replaces repeated sibling scans during authentication and
+   * policy evaluation while keeping subsequent writes immediately visible.
+   */
+  const federationSnapshot = Effect.fn("host.Node.federationSnapshot")(function* () {
+    const epoch = federationEpoch;
+    if (cachedFederation?.epoch === epoch) return cachedFederation.value;
+    if (loadingFederation?.epoch === epoch)
+      return yield* Effect.promise(() => loadingFederation!.value);
+
+    const loading = Effect.runPromise(loadFederation());
+    loadingFederation = { epoch, value: loading };
+    const value = yield* Effect.promise(async () => {
+      try {
+        const loaded = await loading;
+        if (federationEpoch === epoch) cachedFederation = { epoch, value: loaded };
+        return loaded;
+      } finally {
+        if (loadingFederation?.value === loading) loadingFederation = null;
+      }
+    });
+    return value;
+  });
+
+  const invalidateFederation = () => {
+    federationEpoch++;
+    cachedFederation = null;
+  };
 
   const federation = Layer.merge(
-    Layer.succeed(Identities)({ resolve: identityAt }),
-    Layer.succeed(SocialWeb)({ logs: localSocialLogs() }),
+    Layer.succeed(Identities)({
+      resolve: (wanted) =>
+        federationSnapshot().pipe(
+          Effect.map((snapshot) => snapshot.identities.get(wanted) ?? null),
+        ),
+    }),
+    Layer.succeed(SocialWeb)({
+      logs: federationSnapshot().pipe(Effect.map((snapshot) => snapshot.logs)),
+    }),
   );
 
   const stateFor = (repo: string): RepoState => {
@@ -443,6 +496,11 @@ export const serve = async (options: ServeOptions): Promise<Server> => {
     let response: Response;
     try {
       response = await answered;
+      // Git writes and JSON mutations are POST/PUT/PATCH/DELETE requests.
+      // Invalidating after any non-safe request is deliberately conservative:
+      // read-only POST endpoints merely refresh the index next time, while a
+      // ref update is visible to every following request immediately.
+      if (request.method !== "GET" && request.method !== "HEAD") invalidateFederation();
     } finally {
       state.active -= 1;
     }

--- a/src/hub/Event.ts
+++ b/src/hub/Event.ts
@@ -36,6 +36,7 @@ import { checkRefName, isOid, type Oid } from "../git/Store.ts";
 import { checkCapability } from "../trust/Certificate.ts";
 import type { RepoId } from "../trust/Genesis.ts";
 import * as Log from "../trust/Log.ts";
+import { isPrincipalId } from "../trust/Principal.ts";
 import * as Record from "../trust/Record.ts";
 
 const decoder = new TextDecoder();
@@ -228,6 +229,12 @@ export const ReviewSubmitted = Schema.Struct({
   head: Schema.String,
   decision: Schema.Literals(["approve", "reject", "comment"]),
   body: Schema.String,
+  /** Stable identity for a reviewer outside this repository's membership. */
+  principal: Schema.optional(Schema.String),
+  /** External reviews pin the destination they were made for. */
+  base: Schema.optional(Schema.String),
+  /** Exact identity-log view under which the external signing key was current. */
+  identityHead: Schema.optional(Schema.String),
 });
 
 export const ReviewDismissed = Schema.Struct({
@@ -443,6 +450,37 @@ export const validate = Effect.fn("hub.Event.validate")(function* (
     return yield* new Invalid({
       field: "trustHead",
       reason: `'${payload.trustHead}' is not an object id`,
+    });
+  }
+
+  if (payload.type === "review.submitted" && payload.principal !== undefined) {
+    if (!isPrincipalId(payload.principal)) {
+      return yield* new Invalid({
+        field: "principal",
+        reason: `'${payload.principal}' is not a PrincipalID`,
+      });
+    }
+    if (payload.base === undefined || !payload.base.startsWith("refs/heads/")) {
+      return yield* new Invalid({
+        field: "base",
+        reason: "an external review must name a full refs/heads/* destination",
+      });
+    }
+    if (payload.identityHead === undefined || !isOid(payload.identityHead)) {
+      return yield* new Invalid({
+        field: "identityHead",
+        reason: "an external review must pin an identity trust-log head",
+      });
+    }
+  }
+  if (
+    payload.type === "review.submitted" &&
+    payload.principal === undefined &&
+    payload.identityHead !== undefined
+  ) {
+    return yield* new Invalid({
+      field: "identityHead",
+      reason: "only an external review may name an identity trust-log head",
     });
   }
 

--- a/src/hub/Projection.ts
+++ b/src/hub/Projection.ts
@@ -28,6 +28,7 @@ import type { Invalid, ObjectNotFound, StorageFailure } from "../git/Error.ts";
 import type { Oid } from "../git/Store.ts";
 import { permits } from "../trust/Certificate.ts";
 import type { Genesis } from "../trust/Genesis.ts";
+import type { PrincipalId } from "../trust/Principal.ts";
 import type { Projection as TrustProjection } from "../trust/Projection.ts";
 import * as Log from "../trust/Log.ts";
 import * as Verify from "../trust/Verify.ts";
@@ -36,6 +37,8 @@ import * as Event from "./Event.ts";
 export interface Review {
   readonly id: string;
   readonly author: Fingerprint;
+  /** Stable identity behind `author`, when membership resolved through one. */
+  readonly principal: PrincipalId | null;
   /** The exact revision reviewed. An approval is of a revision, never of a PR. */
   readonly head: Oid;
   /** The branch it was reviewed *for*; retargeting the pull request stales it. */
@@ -124,6 +127,8 @@ export interface PullRequest {
    * of, whichever event you used to propose it.
    */
   readonly openers: ReadonlySet<Fingerprint>;
+  /** Stable identities that proposed a revision, across all of their devices. */
+  readonly openerPrincipals: ReadonlySet<PrincipalId>;
   /**
    * The commits whose payloads a valid tombstone reached.
    *
@@ -534,6 +539,7 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
    * establish.
    */
   const openers = new Set<Fingerprint>();
+  const openerPrincipals = new Set<PrincipalId>();
 
   /** Which members signed each event, for the contested-opening ranking. */
   const members = new Map<Oid, ReadonlySet<Fingerprint>>();
@@ -587,6 +593,9 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
       if (authorized.ok) {
         candidates.push(entry.commit);
         openers.add(authorized.principal.fingerprint);
+        if (authorized.identity !== undefined) {
+          openerPrincipals.add(authorized.identity.principal);
+        }
       }
     }
 
@@ -859,6 +868,7 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
     }
 
     const signer = authorized.principal.fingerprint;
+    const stable = authorized.identity?.principal ?? null;
 
     // The claim is per *author*, not per id, and that is the whole defence.
     // An id is chosen by whoever writes the event, so a global claim let the
@@ -956,6 +966,7 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
         // approval on their own by declaring a stale head on a second
         // `pr.opened`.
         openers.add(signer);
+        if (stable !== null) openerPrincipals.add(stable);
         openings.push({ commit: entry.commit, base: Event.branchRef(payload.base) });
         if (supersedes({ commit: entry.commit, id: payload.id }, opened, ancestors)) {
           opened = { commit: entry.commit, id: payload.id };
@@ -1002,7 +1013,10 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
         }
 
         const head = Event.unqualify(payload.head);
-        if (head !== null) openers.add(signer);
+        if (head !== null) {
+          openers.add(signer);
+          if (stable !== null) openerPrincipals.add(stable);
+        }
         // Whoever moved the head proposed the revision under review, which is
         // the thing `approvals` excludes. Keyed on the opening alone, a member
         // holding `hub.merge` could push a revision onto somebody else's pull
@@ -1081,6 +1095,7 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
         reviews.set(mine, {
           id: payload.id,
           author: signer,
+          principal: stable,
           head,
           // Filled in below, from the openings this review descends from
           // rather than from whichever one the walk happened to reach first.
@@ -1342,6 +1357,7 @@ const fold = Effect.fn("hub.Projection.fold")(function* (
     checks: [...checks.values()],
     claims: byId,
     openers,
+    openerPrincipals,
     redacted,
     rejected,
     at,
@@ -1362,7 +1378,7 @@ export const approvals = (pullRequest: PullRequest): ReadonlyArray<Review> => {
   // member satisfy "two approvals required" alone — and it is each author's
   // *latest* word that counts, so a later "request changes" withdraws their
   // earlier approval rather than sitting beside it.
-  const latest = new Map<Fingerprint, Review>();
+  const latest = new Map<string, Review>();
   for (const review of pullRequest.reviews) {
     if (review.stale || review.dismissed) continue;
     // Self-approval satisfies nothing. Without this, one member holding
@@ -1371,6 +1387,9 @@ export const approvals = (pullRequest: PullRequest): ReadonlyArray<Review> => {
     // claimed opener, not merely `author`: a contested opening establishes no
     // author, and an approval from either claimant is still their own.
     if (pullRequest.openers.has(review.author)) continue;
+    if (review.principal !== null && pullRequest.openerPrincipals.has(review.principal)) {
+      continue;
+    }
     // A verdict, and only a verdict. A `comment` review takes no position —
     // it costs `hub.review` rather than `hub.approve`, which is the whole
     // difference — so letting one supersede was the lower capability
@@ -1384,7 +1403,7 @@ export const approvals = (pullRequest: PullRequest): ReadonlyArray<Review> => {
     // order is `Dag.topological`, which is ancestry with a deterministic
     // tie-break — the same discipline `supersedes` applies for the same
     // reason, and `reviews` is built in it.
-    latest.set(review.author, review);
+    latest.set(review.principal ?? review.author, review);
   }
   return [...latest.values()].filter((review) => review.decision === "approve");
 };

--- a/src/hub/PullRequest.ts
+++ b/src/hub/PullRequest.ts
@@ -20,6 +20,7 @@ import { Invalid, type ObjectNotFound, type StorageFailure } from "../git/Error.
 import { Repository } from "../git/Repository.ts";
 import type { Oid } from "../git/Store.ts";
 import { readGenesis, type RepoId } from "../trust/Genesis.ts";
+import type { PrincipalId } from "../trust/Principal.ts";
 import { permits } from "../trust/Certificate.ts";
 import { openWindow, project as projectTrust } from "../trust/Projection.ts";
 import { LOG_REF } from "../trust/Log.ts";
@@ -148,16 +149,56 @@ export const review = Effect.fn("hub.PullRequest.review")(function* (input: {
   readonly head: Oid;
   readonly decision: "approve" | "reject" | "comment";
   readonly body?: string;
+  /** Present only when this is a federated review outside project membership. */
+  readonly principal?: PrincipalId;
+  /** Required with `principal`; external reviews pin their destination. */
+  readonly base?: string;
+  /** Required with `principal`; pins the identity view authorizing its device key. */
+  readonly identityHead?: Oid;
   readonly key: PrivateKey;
 }) {
+  const externalBase = input.base;
+  if (
+    input.principal !== undefined &&
+    (externalBase === undefined || input.identityHead === undefined)
+  ) {
+    return yield* new Invalid({
+      field: externalBase === undefined ? "base" : "identityHead",
+      reason:
+        externalBase === undefined
+          ? "an external review must name the branch it reviews"
+          : "an external review must pin the identity trust-log head it was signed against",
+    });
+  }
   const base = yield* context(input.repo, input.pr);
+  const payload = {
+    ...base,
+    type: "review.submitted" as const,
+    head: Event.qualify(input.head),
+    decision: input.decision,
+    body: input.body ?? "",
+  };
+  if (input.principal === undefined) {
+    if (input.identityHead !== undefined) {
+      return yield* new Invalid({
+        field: "identityHead",
+        reason: "only an external review may pin an identity trust-log head",
+      });
+    }
+    return yield* Event.issue(payload, input.key);
+  }
+  if (externalBase === undefined || input.identityHead === undefined) {
+    return yield* new Invalid({
+      field: externalBase === undefined ? "base" : "identityHead",
+      reason: "an external review must pin its branch and identity trust-log head",
+    });
+  }
   return yield* Event.issue(
     {
-      ...base,
-      type: "review.submitted",
-      head: Event.qualify(input.head),
-      decision: input.decision,
-      body: input.body ?? "",
+      ...payload,
+      principal: input.principal,
+      base: Event.branchRef(externalBase),
+      identityHead: input.identityHead,
     },
     input.key,
   );
@@ -339,7 +380,10 @@ export const redact = Effect.fn("hub.PullRequest.redact")(function* (input: {
       reason: `${input.pr} has ${claimants.length} events claiming ${input.target}`,
     });
   }
-  const targetCommit = claimants[0]!;
+  const targetCommit = claimants[0];
+  if (targetCommit === undefined) {
+    return yield* new Invalid({ field: "target", reason: `${input.target} has no event commit` });
+  }
 
   const { events } = yield* Event.entries(input.pr);
   const target = events.find((entry) => entry.commit === targetCommit);

--- a/src/server/Api.ts
+++ b/src/server/Api.ts
@@ -2833,7 +2833,10 @@ export const hubHandlers = HttpApiBuilder.group(api, "hub", (group) =>
           // The same retry discipline `Event.appendTo` applies: a lost race
           // re-reads the head and re-judges, because adding an event does not
           // change what it says.
-          Effect.retry({ times: 3, while: (error) => error._tag === "RefConflict" }),
+          Effect.retry({
+            times: 3,
+            while: (error) => error._tag === "RefConflict",
+          }),
         );
         return { ref: target.ref, commit };
       }).pipe(Effect.catchTag("StorageFailure", Effect.die)),
@@ -2990,7 +2993,12 @@ export const hubHandlers = HttpApiBuilder.group(api, "hub", (group) =>
           }
           yield* repository.setRef({ name: ref, to: record, expected: prHead });
           return { pr: params.id, base: pull.base, commit: payload.head, event: record };
-        }).pipe(Effect.retry({ times: 3, while: (error) => error._tag === "RefConflict" }));
+        }).pipe(
+          Effect.retry({
+            times: 3,
+            while: (error) => error._tag === "RefConflict",
+          }),
+        );
       }).pipe(Effect.catchTag("StorageFailure", Effect.die)),
     ),
 );

--- a/src/server/Auth.test.ts
+++ b/src/server/Auth.test.ts
@@ -167,6 +167,12 @@ describe("Auth", () => {
         "source.push",
         "source.delete",
       ]);
+      assert.deepEqual(
+        requiredCapability(
+          request("r/git-receive-pack", { method: "POST", headers: { "git-inbox": "1" } }),
+        ),
+        ["source.push", "source.delete", "quarantine.submit"],
+      );
     });
 
     it("lets a source.delete holder past the guard, since the guard cannot see the commands", () => {

--- a/src/server/Auth.ts
+++ b/src/server/Auth.ts
@@ -47,6 +47,7 @@ import { Repository } from "../git/Repository.ts";
 import { type Oid, storageOf } from "../git/Store.ts";
 import { type Genesis, readGenesis, type RepoId } from "../trust/Genesis.ts";
 import { LOG_REF } from "../trust/Log.ts";
+import type { ResolvedIdentity } from "../trust/Principal.ts";
 import { type Member, project, type Projection } from "../trust/Projection.ts";
 import { CAPABILITIES, permits } from "../trust/Certificate.ts";
 import * as Verify from "../trust/Verify.ts";
@@ -70,14 +71,17 @@ const decoder = new TextDecoder();
  * written to admit.
  */
 const WRITE = ["source.push", "source.delete"];
+/** Pre-auth receive-pack access; policy permits only a quarantine create. */
+export const INBOX_SUBMIT = "quarantine.submit";
 
 export const requiredCapability = (request: Request): ReadonlyArray<string> => {
   const url = new URL(request.url);
   const last = url.pathname.split("/").at(-1);
 
-  if (last === "git-receive-pack") return WRITE;
+  const inbox = request.headers.get("git-inbox") === "1";
+  if (last === "git-receive-pack") return inbox ? [...WRITE, INBOX_SUBMIT] : WRITE;
   if (last === "refs" && url.searchParams.get("service") === "git-receive-pack") {
-    return WRITE;
+    return inbox ? [...WRITE, INBOX_SUBMIT] : WRITE;
   }
   if (last === "git-upload-pack") return READ;
   // The LFS batch endpoint negotiates downloads as well as uploads, so method
@@ -706,6 +710,8 @@ export interface Authenticated {
   /** What this request may do — narrowed by a delegated credential's scope. */
   readonly capabilities: ReadonlyArray<string>;
   readonly projection: Projection;
+  /** Foreign identity view used when membership resolved through a PrincipalID. */
+  readonly identity?: ResolvedIdentity;
   /**
    * The envelope a native client signed, when it signed one.
    *
@@ -800,24 +806,35 @@ export const authenticate = Effect.fn("Auth.authenticate")(function* (input: {
     // Anonymous reads are a repository policy question; anonymous writes never
     // are. Either way the answer carries a fresh nonce, so a native client
     // learns how to sign its retry from the rejection itself.
-    return readOnly(input.capability) && anonymousReadAllowed(projection)
+    return input.capability.includes(INBOX_SUBMIT)
       ? ({
           ok: true,
           authenticated: {
             principal: null,
             signer: null,
-            capabilities: ["repo.read"],
+            capabilities: [INBOX_SUBMIT],
             projection,
             envelope: null,
           },
         } as const)
-      : ({
-          ok: false,
-          status: 401,
-          reason: "authentication required",
-          nonce: yield* nonces.issue(300),
-          repo: projection.repoId,
-        } as const);
+      : readOnly(input.capability) && anonymousReadAllowed(projection)
+        ? ({
+            ok: true,
+            authenticated: {
+              principal: null,
+              signer: null,
+              capabilities: ["repo.read"],
+              projection,
+              envelope: null,
+            },
+          } as const)
+        : ({
+            ok: false,
+            status: 401,
+            reason: "authentication required",
+            nonce: yield* nonces.issue(300),
+            repo: projection.repoId,
+          } as const);
   }
 
   const identified =
@@ -841,24 +858,35 @@ export const authenticate = Effect.fn("Auth.authenticate")(function* (input: {
     // credential presented is nonsense: `git` sends whatever a credential
     // helper has for the host, and refusing here would break clones for
     // people whose only mistake was having an unrelated entry.
-    return readOnly(input.capability) && anonymousReadAllowed(projection)
+    return input.capability.includes(INBOX_SUBMIT)
       ? ({
           ok: true,
           authenticated: {
             principal: null,
             signer: null,
-            capabilities: ["repo.read"],
+            capabilities: [INBOX_SUBMIT],
             projection,
             envelope: null,
           },
         } as const)
-      : ({
-          ok: false,
-          status: 401,
-          reason: "credential did not verify",
-          nonce: yield* nonces.issue(300),
-          repo: projection.repoId,
-        } as const);
+      : readOnly(input.capability) && anonymousReadAllowed(projection)
+        ? ({
+            ok: true,
+            authenticated: {
+              principal: null,
+              signer: null,
+              capabilities: ["repo.read"],
+              projection,
+              envelope: null,
+            },
+          } as const)
+        : ({
+            ok: false,
+            status: 401,
+            reason: "credential did not verify",
+            nonce: yield* nonces.issue(300),
+            repo: projection.repoId,
+          } as const);
   }
 
   // Any one of them: a holder of `source.delete` and a holder of
@@ -884,6 +912,18 @@ export const authenticate = Effect.fn("Auth.authenticate")(function* (input: {
     // readable because a credential was presented: `git` sends one on every
     // request once it has any, and refusing here would break a clone that
     // works without it.
+    if (input.capability.includes(INBOX_SUBMIT)) {
+      return {
+        ok: true,
+        authenticated: {
+          principal: null,
+          signer: identified.signer,
+          capabilities: [INBOX_SUBMIT],
+          projection,
+          envelope: null,
+        },
+      } as const;
+    }
     if (readOnly(input.capability) && anonymousReadAllowed(projection)) {
       return {
         ok: true,
@@ -940,16 +980,18 @@ export const authenticate = Effect.fn("Auth.authenticate")(function* (input: {
     } as const;
   }
 
-  return {
-    ok: true,
-    authenticated: {
-      principal: authorized.principal,
-      signer: identified.signer,
-      capabilities: scoped,
-      projection,
-      envelope: "envelope" in identified ? identified.envelope : null,
-    },
-  } as const;
+  const baseAuthentication: Authenticated = {
+    principal: authorized.principal,
+    signer: identified.signer,
+    capabilities: scoped,
+    projection,
+    envelope: "envelope" in identified ? identified.envelope : null,
+  };
+  const authenticated: Authenticated =
+    authorized.identity === undefined
+      ? baseAuthentication
+      : { ...baseAuthentication, identity: authorized.identity };
+  return { ok: true, authenticated } as const;
 });
 
 /** The projection a repository with no genesis presents: nothing is known. */
@@ -962,6 +1004,9 @@ const EMPTY: Projection = {
   members: new Map(),
   former: new Map(),
   revoked: new Map(),
+  principals: new Map(),
+  formerPrincipals: new Map(),
+  revokedPrincipals: new Map(),
   roots: [],
   threshold: 0,
   checkpoint: null,

--- a/src/server/Policy.external.test.ts
+++ b/src/server/Policy.external.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { fingerprint, formatPublicKey, generate } from "../crypto/SshSignature.ts";
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import { EMPTY_TREE_OID, type Signature } from "../git/Format.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import type { Oid } from "../git/Store.ts";
+import * as PullRequest from "../hub/PullRequest.ts";
+import type { VerifiedLog, VerifiedStatement } from "../social/Log.ts";
+import { socialWebInMemory } from "../social/Projection.ts";
+import type { ExternalReview } from "../social/Review.ts";
+import { encode, vouch, type SocialStatement } from "../social/Statement.ts";
+import * as Certificate from "../trust/Certificate.ts";
+import type { RepoId } from "../trust/Genesis.ts";
+import { create, signGenesis, writeGenesis } from "../trust/Genesis.ts";
+import * as Log from "../trust/Log.ts";
+import {
+  identitiesInMemory,
+  principalId,
+  type PrincipalId,
+  type ResolvedIdentity,
+} from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import { eligibleExternalApprovals, evaluate, OPEN, type ExternalReviewRule } from "./Policy.ts";
+
+/** SAFETY: test values have the exact branded wire shapes. */
+const repoId = (seed: string): RepoId => `SHA256:${seed.repeat(43).slice(0, 43)}` as RepoId;
+const principal = (seed: string): PrincipalId => principalId(repoId(seed));
+/** SAFETY: exactly forty lowercase hexadecimal characters. */
+const oid = (seed: number): Oid => seed.toString(16).padStart(40, "0") as Oid;
+/** SAFETY: the same 43-character digest spelling as a real fingerprint. */
+const signer = (seed: string): Fingerprint =>
+  `SHA256:${seed.repeat(43).slice(0, 43)}` as Fingerprint;
+
+const rootA = principal("a");
+const rootB = principal("b");
+const reviewer = principal("r");
+const reviewerKey = signer("k");
+
+const statement = (payload: SocialStatement, commit: Oid): VerifiedStatement => ({
+  commit,
+  parents: [],
+  payload,
+  bytes: encode(payload),
+  signatures: [],
+  signer: signer(payload.author.slice(7, 8)),
+});
+
+const endorsement = (
+  author: PrincipalId,
+  index: number,
+  subject: PrincipalId = reviewer,
+): VerifiedLog => {
+  const payload = vouch({
+    author,
+    subject,
+    id: `018bcfe5-6800-7000-8000-${index.toString().padStart(12, "0")}`,
+    socialHead: null,
+    trustHead: null,
+    at: new Date("2026-08-20T00:00:00Z"),
+    scope: ["review"],
+    depth: 0,
+  });
+  const commit = oid(index);
+  return {
+    principal: author,
+    head: commit,
+    statements: [statement(payload, commit)],
+    rejected: [],
+  };
+};
+
+const review: ExternalReview = {
+  principal: reviewer,
+  id: "review-1",
+  author: reviewerKey,
+  head: oid(100),
+  base: "refs/heads/main",
+  commit: oid(101),
+  decision: "approve",
+  body: "looks good",
+  at: new Date("2026-08-20T00:00:00Z"),
+  dismissed: false,
+  stale: false,
+};
+
+const rule: ExternalReviewRule = {
+  branch: "refs/heads/main",
+  anchors: [rootA, rootB],
+  scope: "review",
+  maxDepth: 1,
+  minPaths: 2,
+  maxCount: 1,
+};
+
+const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        GitRepository.layer.pipe(
+          Layer.provide(GitRepository.hooksNoop),
+          Layer.provideMerge(stores),
+        ),
+      ),
+    ),
+  );
+
+const author: Signature = {
+  name: "Alice",
+  email: "alice@example.com",
+  at: new Date("2026-08-20T00:00:00Z"),
+  offset: 0,
+};
+
+describe("external-review policy", () => {
+  it.effect("counts only reviewers meeting the rooted independent-path bar", () =>
+    Effect.sync(() => {
+      const both = eligibleExternalApprovals({
+        rule,
+        logs: [endorsement(rootA, 1), endorsement(rootB, 2)],
+        reviews: [review],
+      });
+      const one = eligibleExternalApprovals({
+        rule,
+        logs: [endorsement(rootA, 1)],
+        reviews: [review],
+      });
+      const sameKey = eligibleExternalApprovals({
+        rule,
+        logs: [endorsement(rootA, 1), endorsement(rootB, 2)],
+        reviews: [review],
+        internal: [review],
+      });
+
+      assert.equal(both.length, 1);
+      assert.equal(one.length, 0);
+      assert.equal(sameKey.length, 0, "one reviewer cannot count once locally and once externally");
+    }),
+  );
+
+  it.effect("lets an opted-in protected branch count an identity-verified external approval", () =>
+    Effect.promise(async () => {
+      const identity = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("identity-root@example.com");
+          const key = yield* generate("external-reviewer@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(key.publicKey),
+              capabilities: [],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const projection = yield* projectTrust(genesis);
+          return {
+            key,
+            resolved: {
+              principal: principalId(genesis.repoId),
+              projection,
+              head: projection.head,
+            } satisfies ResolvedIdentity,
+          };
+        }),
+      );
+
+      const outcome = await scenario(
+        Effect.gen(function* () {
+          const repository = yield* Repository;
+          const root = yield* generate("project-root@example.com");
+          const contributor = yield* generate("contributor@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          const capabilities = ["source.push", "hub.create-pr"];
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(contributor.publicKey),
+              capabilities,
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const trust = yield* projectTrust(genesis);
+          const contributorPrint = yield* fingerprint(contributor.publicKey);
+          const member = trust.members.get(contributorPrint);
+          if (member === undefined) assert.fail("the contributor grant must project as a member");
+          const revision = yield* repository.commit({
+            branch: "refs/heads/topic",
+            tree: EMPTY_TREE_OID,
+            message: "proposal",
+            author,
+          });
+          const opened = yield* PullRequest.open({
+            repo: genesis.repoId,
+            title: "federated",
+            base: "refs/heads/main",
+            head: revision,
+            key: contributor,
+          });
+          if (identity.resolved.head === null) {
+            assert.fail("the identity fixture must have a trust-log head");
+          }
+          yield* PullRequest.review({
+            repo: genesis.repoId,
+            pr: opened.pr,
+            head: revision,
+            base: "refs/heads/main",
+            principal: identity.resolved.principal,
+            identityHead: identity.resolved.head,
+            decision: "approve",
+            key: identity.key,
+          });
+
+          const judge = (
+            logs: ReadonlyArray<VerifiedLog>,
+            externalBranch: ExternalReviewRule["branch"] = "refs/heads/main",
+          ) =>
+            evaluate({
+              update: { name: "refs/heads/main", value: revision },
+              principal: { member, capabilities },
+              genesis,
+              trust,
+              rules: {
+                ...OPEN,
+                protected: ["refs/heads/main"],
+                requirePullRequest: true,
+                requiredApprovals: 1,
+                externalReview: { ...rule, branch: externalBranch, anchors: [rootA, rootB] },
+              },
+            }).pipe(
+              Effect.provide(identitiesInMemory([identity.resolved])),
+              Effect.provide(socialWebInMemory(logs)),
+            );
+
+          return {
+            accepted: yield* judge([
+              endorsement(rootA, 1, identity.resolved.principal),
+              endorsement(rootB, 2, identity.resolved.principal),
+            ]),
+            refused: yield* judge([endorsement(rootA, 1, identity.resolved.principal)]),
+            wrongBranch: yield* judge(
+              [
+                endorsement(rootA, 1, identity.resolved.principal),
+                endorsement(rootB, 2, identity.resolved.principal),
+              ],
+              "refs/heads/release",
+            ),
+          };
+        }),
+      );
+
+      assert.equal(
+        outcome.accepted.ok,
+        true,
+        outcome.accepted.ok ? "accepted" : outcome.accepted.reason,
+      );
+      assert.equal(outcome.refused.ok, false);
+      assert.equal(
+        outcome.wrongBranch.ok,
+        false,
+        "external trust policy is scoped to one exact ref",
+      );
+    }),
+  );
+});

--- a/src/server/Policy.test.ts
+++ b/src/server/Policy.test.ts
@@ -17,9 +17,13 @@ import * as Event from "../hub/Event.ts";
 import * as PullRequest from "../hub/PullRequest.ts";
 import * as Session from "../hub/Session.ts";
 import * as Task from "../hub/Task.ts";
+import * as Inbox from "../social/Inbox.ts";
+import * as SocialLog from "../social/Log.ts";
+import * as Statement from "../social/Statement.ts";
 import * as Certificate from "../trust/Certificate.ts";
 import { create, type Genesis, GENESIS_REF, signGenesis, writeGenesis } from "../trust/Genesis.ts";
 import * as Log from "../trust/Log.ts";
+import { principalId } from "../trust/Principal.ts";
 import { type Member, project as projectTrust } from "../trust/Projection.ts";
 import * as Auth from "./Auth.ts";
 import * as Policy from "./Policy.ts";
@@ -34,6 +38,9 @@ const EMPTY_PROJECTION = {
   members: new Map(),
   former: new Map(),
   revoked: new Map(),
+  principals: new Map(),
+  formerPrincipals: new Map(),
+  revokedPrincipals: new Map(),
   roots: [],
   threshold: 0,
   checkpoint: null,
@@ -259,6 +266,139 @@ describe("Policy", () => {
   });
 
   describe("namespaces", () => {
+    it("admits only the social log and charges social.write to append it", async () => {
+      const outcome = await scenario(
+        Effect.gen(function* () {
+          const repository = yield* Repository;
+          const allowed = yield* world(["source.push", "social.write"]);
+          const allowedTrust = yield* trustOf(allowed);
+          const allowedPrincipal = principalId(allowed.genesis.repoId);
+          const allowedHead = yield* SocialLog.issue(
+            Statement.follow({
+              author: allowedPrincipal,
+              subject: allowedPrincipal,
+              id: SocialLog.newId(),
+              socialHead: null,
+              trustHead: allowedTrust.head,
+              petname: "self",
+            }),
+            allowed.dev,
+          );
+          yield* repository.deleteRef(SocialLog.LOG_REF);
+
+          const accepted = yield* judge(allowed, {
+            name: SocialLog.LOG_REF,
+            value: allowedHead,
+          });
+          const stray = yield* judge(allowed, {
+            name: "refs/social/notes",
+            value: allowedHead,
+          });
+
+          const missingCapability = yield* judge(
+            {
+              ...allowed,
+              principal: { ...allowed.principal, capabilities: ["source.push"] },
+            },
+            {
+              name: SocialLog.LOG_REF,
+              value: allowedHead,
+            },
+          );
+
+          return { accepted, stray, missingCapability };
+        }),
+      );
+
+      assert.equal(outcome.accepted.ok, true);
+      assert.equal(outcome.stray.ok, false);
+      assert.match(
+        outcome.stray.ok === false ? outcome.stray.reason : "",
+        /not part of the social namespace/,
+      );
+      assert.equal(outcome.missingCapability.ok, false);
+      assert.match(
+        outcome.missingCapability.ok === false ? outcome.missingCapability.reason : "",
+        /social\.write/,
+      );
+    });
+
+    it("refuses a newly pushed social statement signed by a revoked device", async () => {
+      const decision = await scenario(
+        Effect.gen(function* () {
+          const repository = yield* Repository;
+          const where = yield* world(["source.push", "social.write"]);
+          const beforeRevocation = yield* trustOf(where);
+          yield* Log.issue(
+            Certificate.revoke({
+              repo: where.genesis.repoId,
+              subject: yield* fingerprint(where.dev.publicKey),
+              reason: "rotated",
+              id: Log.newId(),
+            }),
+            [where.root],
+          );
+
+          const principal = principalId(where.genesis.repoId);
+          const head = yield* SocialLog.issue(
+            Statement.follow({
+              author: principal,
+              subject: principal,
+              id: SocialLog.newId(),
+              socialHead: null,
+              trustHead: beforeRevocation.head,
+              petname: "backdated",
+            }),
+            where.dev,
+          );
+          yield* repository.deleteRef(SocialLog.LOG_REF);
+          return yield* judge(where, { name: SocialLog.LOG_REF, value: head });
+        }),
+      );
+
+      assert.equal(decision.ok, false);
+      assert.match(decision.ok === false ? decision.reason : "", /revoked.*social\.follow/);
+    });
+
+    it("keeps the inbox quarantine writable only through its dedicated operation", async () => {
+      const outcome = await scenario(
+        Effect.gen(function* () {
+          const where = yield* world(["source.push"]);
+          const { second } = yield* history("refs/heads/proposal");
+          const trust = yield* trustOf(where);
+          const id = "018bcfe5-6800-7000-8000-000000000001";
+          return {
+            push: yield* judge(where, {
+              name: "refs/quarantine/inbox/proposal",
+              value: second,
+            }),
+            api: yield* gateWriteAs(where, "refs/quarantine/inbox/proposal"),
+            inbox: yield* evaluate({
+              update: { name: `${Inbox.PENDING_PREFIX}${id}`, value: second },
+              principal: { member: null, capabilities: [Auth.INBOX_SUBMIT] },
+              genesis: where.genesis,
+              trust,
+              rules: OPEN,
+            }),
+            malformed: yield* evaluate({
+              update: { name: "refs/quarantine/inbox/proposal", value: second },
+              principal: { member: null, capabilities: [Auth.INBOX_SUBMIT] },
+              genesis: where.genesis,
+              trust,
+              rules: OPEN,
+            }),
+          };
+        }),
+      );
+
+      assert.equal(outcome.push.ok, false);
+      assert.match(outcome.push.ok ? "" : outcome.push.reason, /quarantine operation/);
+      assert.match(outcome.api ?? "", /quarantine operation/);
+      assert.equal(outcome.inbox.ok, true);
+      assert.equal(outcome.malformed.ok, false);
+      assert.match(outcome.malformed.ok ? "" : outcome.malformed.reason, /UUIDv7/);
+    });
+
     it("refuses to move the genesis", async () => {
       const decision = await scenario(
         Effect.gen(function* () {

--- a/src/server/Policy.ts
+++ b/src/server/Policy.ts
@@ -43,15 +43,23 @@ import * as Event from "../hub/Event.ts";
 import * as Tombstone from "../hub/Tombstone.ts";
 import * as Session from "../hub/Session.ts";
 import * as Task from "../hub/Task.ts";
+import * as SocialLog from "../social/Log.ts";
+import * as Inbox from "../social/Inbox.ts";
+import * as Statement from "../social/Statement.ts";
 import {
   approvals,
   checksPassed,
   project as projectPr,
+  type Review,
   type PullRequest as PullRequestState,
 } from "../hub/Projection.ts";
+import type { VerifiedLog } from "../social/Log.ts";
+import * as SocialProjection from "../social/Projection.ts";
+import { externalReviews, type ExternalReview } from "../social/Review.ts";
 import { permits } from "../trust/Certificate.ts";
 import * as Log from "../trust/Log.ts";
 import * as Record from "../trust/Record.ts";
+import { principalOf, principalSubject, type PrincipalId } from "../trust/Principal.ts";
 import * as Verify from "../trust/Verify.ts";
 import * as Auth from "./Auth.ts";
 
@@ -62,6 +70,17 @@ import * as Auth from "./Auth.ts";
  * branch has not protected it, and inventing protection nobody asked for would
  * break every existing push.
  */
+export interface ExternalReviewRule {
+  /** Exact protected branch this opt-in applies to. */
+  readonly branch: string;
+  /** Repository-selected roots; a pusher cannot bring their own web. */
+  readonly anchors: ReadonlyArray<PrincipalId>;
+  readonly scope: "review";
+  readonly maxDepth: number;
+  readonly minPaths: number;
+  readonly maxCount: number;
+}
+
 export interface Rules {
   /**
    * Full ref names, or prefixes with a trailing `*`.
@@ -110,6 +129,8 @@ export interface Rules {
    */
   readonly maxUsageTokens: number;
   readonly usageWindowSeconds: number;
+  /** Opt-in only; omitted and `null` both mean external reviews never count. */
+  readonly externalReview?: ExternalReviewRule | null;
 }
 
 /** Re-exported where the boundary reads it; defined beside the guard. */
@@ -126,6 +147,7 @@ export const OPEN: Rules = {
   requireProvenance: false,
   maxUsageTokens: 0,
   usageWindowSeconds: 0,
+  externalReview: null,
 };
 
 /** Where a repository keeps its branch rules, if it has any. */
@@ -145,6 +167,18 @@ const RulesDocument = Schema.Struct({
   requireProvenance: Schema.optional(Schema.Boolean),
   maxUsageTokens: Schema.optional(Schema.Int),
   usageWindowSeconds: Schema.optional(Schema.Int),
+  externalReview: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        branch: Schema.String,
+        anchors: Schema.Array(Schema.String),
+        scope: Schema.Literal("review"),
+        maxDepth: Schema.Int,
+        minPaths: Schema.Int,
+        maxCount: Schema.Int,
+      }),
+    ),
+  ),
 });
 
 const decodeRules = Schema.decodeUnknownEffect(RulesDocument);
@@ -165,6 +199,13 @@ export const encodeRules = (rules: Rules): Uint8Array =>
         requireProvenance: rules.requireProvenance,
         maxUsageTokens: rules.maxUsageTokens,
         usageWindowSeconds: rules.usageWindowSeconds,
+        externalReview:
+          rules.externalReview === undefined || rules.externalReview === null
+            ? null
+            : {
+                ...rules.externalReview,
+                anchors: rules.externalReview.anchors.map(principalSubject),
+              },
       },
       null,
       2,
@@ -209,6 +250,38 @@ export const rulesOf = Effect.fn("Policy.rulesOf")(function* () {
     ),
   );
 
+  let externalReview: ExternalReviewRule | null = null;
+  if (loaded.externalReview !== undefined && loaded.externalReview !== null) {
+    const anchors: PrincipalId[] = [];
+    for (const anchor of loaded.externalReview.anchors) {
+      const parsed = principalOf(anchor);
+      if (parsed === null) {
+        return yield* new Invalid({
+          field: "policy.externalReview.anchors",
+          reason: `'${anchor}' is not a principal:<PrincipalID> subject`,
+        });
+      }
+      anchors.push(parsed);
+    }
+    if (
+      !loaded.externalReview.branch.startsWith("refs/heads/") ||
+      loaded.externalReview.branch.includes("*") ||
+      anchors.length === 0 ||
+      loaded.externalReview.maxDepth < 0 ||
+      loaded.externalReview.maxDepth > 16 ||
+      loaded.externalReview.minPaths < 1 ||
+      loaded.externalReview.maxCount < 0
+    ) {
+      return yield* new Invalid({
+        field: "policy.externalReview",
+        reason:
+          "branch must be one exact refs/heads/* name, anchors must be non-empty, " +
+          "maxDepth must be 0..16, minPaths at least 1, and maxCount non-negative",
+      });
+    }
+    externalReview = { ...loaded.externalReview, anchors };
+  }
+
   return {
     protected: loaded.protected,
     requiredApprovals: loaded.requiredApprovals,
@@ -219,8 +292,38 @@ export const rulesOf = Effect.fn("Policy.rulesOf")(function* () {
     requireProvenance: loaded.requireProvenance ?? false,
     maxUsageTokens: loaded.maxUsageTokens ?? 0,
     usageWindowSeconds: loaded.usageWindowSeconds ?? 0,
+    externalReview,
   };
 });
+
+/** External approvals that meet a repository-selected rooted confidence bar. */
+export const eligibleExternalApprovals = (input: {
+  readonly rule: ExternalReviewRule;
+  readonly logs: ReadonlyArray<VerifiedLog>;
+  readonly reviews: ReadonlyArray<ExternalReview>;
+  readonly internal?: ReadonlyArray<Review>;
+}): ReadonlyArray<ExternalReview> => {
+  const graph = SocialProjection.project({
+    roots: input.rule.anchors,
+    logs: input.logs,
+    maxDepth: input.rule.maxDepth,
+  });
+  const internal = new Set(
+    (input.internal ?? []).map((review) => review.principal ?? review.author),
+  );
+  return input.reviews
+    .filter(
+      (review) =>
+        !internal.has(review.principal) &&
+        SocialProjection.confidence(
+          graph,
+          review.principal,
+          input.rule.scope,
+          input.rule.maxDepth,
+        ) >= input.rule.minPaths,
+    )
+    .slice(0, input.rule.maxCount);
+};
 
 /**
  * Pull requests folded once for a batch of ref updates.
@@ -620,6 +723,18 @@ export const evaluate = Effect.fn("Policy.evaluate")(function* (input: {
   ) {
     return refused(update.name, `${update.name} is not part of the trust namespace`);
   }
+  if (update.name.startsWith("refs/social/") && update.name !== Refspec.SOCIAL_LOG) {
+    return refused(update.name, `${update.name} is not part of the social namespace`);
+  }
+  if (update.name.startsWith("refs/quarantine/")) {
+    return yield* quarantineRules({
+      update,
+      current,
+      stored,
+      principal: input.principal,
+      enabled: input.genesis !== null && input.trust !== null,
+    });
+  }
 
   // Not hub-enabled: no genesis, so no members, so nobody holds `source.push`
   // — and §14 is unconditional that anonymous does not get it. A repository
@@ -636,7 +751,7 @@ export const evaluate = Effect.fn("Policy.evaluate")(function* (input: {
     // Identity is never acquired by push, whatever the host allows: whoever
     // got there first would own the repository, and its actual owner would be
     // locked out of it by a stranger.
-    if (update.name.startsWith("refs/meta/trust/")) {
+    if (update.name.startsWith("refs/meta/trust/") || update.name.startsWith("refs/social/")) {
       return refused(
         update.name,
         "a repository's identity is established by `hub init`, not by a push",
@@ -702,13 +817,15 @@ export const evaluate = Effect.fn("Policy.evaluate")(function* (input: {
     // holder still passes: a tombstone is the one event either namespace
     // accepts from a signer outside its own capability.
     const needed = (name: string): { exact: ReadonlyArray<string> } | { prefix: string } =>
-      Task.taskOf(name) !== null
-        ? { exact: ["hub.task", "hub.redact"] }
-        : Session.sessionOf(name) !== null
-          ? { exact: ["hub.session", "hub.redact"] }
-          : name.startsWith("refs/hub/")
-            ? { prefix: "hub." }
-            : { prefix: "member." };
+      name === Refspec.SOCIAL_LOG
+        ? { exact: ["social.write"] }
+        : Task.taskOf(name) !== null
+          ? { exact: ["hub.task", "hub.redact"] }
+          : Session.sessionOf(name) !== null
+            ? { exact: ["hub.session", "hub.redact"] }
+            : name.startsWith("refs/hub/")
+              ? { prefix: "hub." }
+              : { prefix: "member." };
     const charge = needed(update.name);
     const passes =
       "exact" in charge
@@ -757,8 +874,11 @@ export const evaluate = Effect.fn("Policy.evaluate")(function* (input: {
   // when they were written, but the boundary knows whose keys are revoked
   // *now*, and a signature arriving now from a key this repository has already
   // revoked is one it has no reason to take.
-  if (update.name.startsWith("refs/hub/") && update.value !== null) {
-    const refusal = yield* signedByRevoked(update.value, current, input.trust, held);
+  if (
+    (update.name.startsWith("refs/hub/") || update.name === Refspec.SOCIAL_LOG) &&
+    update.value !== null
+  ) {
+    const refusal = yield* signedByRevoked(update.name, update.value, current, input.trust, held);
     if (refusal !== null) return refused(update.name, refusal);
   }
 
@@ -783,10 +903,14 @@ export const evaluate = Effect.fn("Policy.evaluate")(function* (input: {
   if (deleting) return refused(update.name, `${update.name} is protected and may not be deleted`);
   if (forced)
     return refused(update.name, `${update.name} is protected and may not be force-pushed`);
+  const protectedValue = update.value;
+  if (protectedValue === null) {
+    return refused(update.name, `${update.name} is protected and may not be deleted`);
+  }
 
   const gate = yield* protectedBranch({
     ref: update.name,
-    to: update.value!,
+    to: protectedValue,
     genesis: input.genesis,
     trust: input.trust,
     rules: input.rules,
@@ -847,7 +971,11 @@ const namespaceRules = Effect.fn("Policy.namespaceRules")(function* (
   // holder could point a hub ref at any source commit at all, on a name that
   // can never be deleted, pinning whatever it reaches out of reach of `gc`
   // for good.
-  const belongs = update.name.startsWith("refs/hub/") ? Event.isHubCommit : Log.isTrustCommit;
+  const belongs = update.name.startsWith("refs/hub/")
+    ? Event.isHubCommit
+    : update.name === Refspec.SOCIAL_LOG
+      ? SocialLog.isSocialCommit
+      : Log.isTrustCommit;
   if (!(yield* belongs(update.value))) {
     return refused(update.name, `${update.value} is not part of ${update.name}'s history`);
   }
@@ -933,6 +1061,57 @@ const namespaceRules = Effect.fn("Policy.namespaceRules")(function* (
   return allowed;
 });
 
+const MAX_INBOX_PROPOSALS = 4096;
+
+/** The only ref transition an unauthenticated receive-pack may perform. */
+const quarantineRules = Effect.fn("Policy.quarantineRules")(function* (input: {
+  readonly update: RefUpdate;
+  readonly current: Oid | null;
+  readonly stored: Oid | null;
+  readonly principal: Principal;
+  readonly enabled: boolean;
+}) {
+  const { update } = input;
+  if (!input.enabled) {
+    return refused(update.name, "an inbox belongs to an identified repository");
+  }
+  if (!update.name.startsWith(Inbox.PENDING_PREFIX)) {
+    return refused(update.name, `${update.name} is not an inbox proposal ref`);
+  }
+  if (!input.principal.capabilities.includes(Auth.INBOX_SUBMIT)) {
+    return refused(update.name, "the inbox may only be written by a quarantine operation");
+  }
+  const id = update.name.slice(Inbox.PENDING_PREFIX.length);
+  if (!Inbox.isProposalId(id)) {
+    return refused(update.name, "an inbox proposal ref must end in a UUIDv7");
+  }
+  if (update.value === null) {
+    return refused(update.name, "an inbox proposal may not be deleted over receive-pack");
+  }
+  if (input.current !== null || input.stored !== null) {
+    return refused(update.name, `inbox proposal '${id}' already exists`);
+  }
+  const repository = yield* Repository;
+  if ((yield* repository.resolve(`${Inbox.ADOPTED_PREFIX}${id}`)) !== null) {
+    return refused(update.name, `inbox proposal '${id}' has already been adopted`);
+  }
+  const commit = yield* repository.readCommit(update.value).pipe(
+    Effect.as(true),
+    Effect.catchTag("ObjectNotFound", () => Effect.succeed(false)),
+  );
+  if (!commit) return refused(update.name, "an inbox proposal must point at a commit");
+
+  let count = 0;
+  for (const [name] of yield* repository.refs) {
+    if (name.startsWith(Inbox.PENDING_PREFIX)) count++;
+  }
+  if (count >= MAX_INBOX_PROPOSALS) {
+    return refused(update.name, `this inbox already holds ${count} pending proposals`);
+  }
+  const expected = update.expected === undefined ? input.stored : update.expected;
+  return { ok: true, allowed: { update, expected } } satisfies Decision;
+});
+
 /**
  * Why an append-only ref may not hold this value, or `null`.
  *
@@ -953,6 +1132,11 @@ const beyondCeiling = Effect.fn("Policy.beyondCeiling")(function* (name: string,
     return (yield* Log.withinCeiling(to))
       ? null
       : `${name} would hold more records than a fold will walk`;
+  }
+  if (name === Refspec.SOCIAL_LOG) {
+    return (yield* SocialLog.withinCeiling(to))
+      ? null
+      : `${name} would hold more statements than a fold will walk`;
   }
 
   return null;
@@ -986,6 +1170,7 @@ const alreadyHeld = Effect.fn("Policy.alreadyHeld")(function* (name: string, cur
 
   const repository = yield* Repository;
   const hub = name.startsWith("refs/hub/");
+  const social = name === Refspec.SOCIAL_LOG;
   const anchor = hub ? null : yield* repository.resolve(Refspec.TRUST_GENESIS);
   // Bounded by the *ceiling*, not by the namespace. Bounded by the namespace,
   // the walk stopped at a commit whose tree object never arrived — a state
@@ -993,7 +1178,11 @@ const alreadyHeld = Effect.fn("Policy.alreadyHeld")(function* (name: string, cur
   // without a connectivity check — and everything behind it dropped out of
   // the set, so the next ordinary reconciling push met an unaccounted parent
   // and was refused for good on a ref that cannot be rewound.
-  const ceiling = hub ? yield* Event.ceilingOf() : yield* Log.ceilingOf();
+  const ceiling = hub
+    ? yield* Event.ceilingOf()
+    : social
+      ? yield* SocialLog.ceilingOf()
+      : yield* Log.ceilingOf();
 
   // Walked here rather than through `Dag.reachable` for the same tolerance in
   // the other direction: a *commit* object that never arrived is still a
@@ -1004,7 +1193,8 @@ const alreadyHeld = Effect.fn("Policy.alreadyHeld")(function* (name: string, cur
   // other refusing an ordinary join for good.
   const pending: Oid[] = [current];
   while (pending.length > 0 && held.size < ceiling) {
-    const oid = pending.pop()!;
+    const oid = pending.pop();
+    if (oid === undefined) break;
     if (held.has(oid) || oid === anchor) continue;
     held.add(oid);
 
@@ -1032,6 +1222,7 @@ const alreadyHeld = Effect.fn("Policy.alreadyHeld")(function* (name: string, cur
  * Only what the push adds is walked, so an ordinary push reads one commit.
  */
 const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
+  ref: string,
   to: Oid,
   current: Oid | null,
   trust: TrustProjection,
@@ -1043,8 +1234,15 @@ const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
   // root and re-judged every event already on the ref. One old comment from a
   // member revoked since then made that pull request refuse its own joins for
   // good, on a namespace that cannot be rewound.
+  const social = ref === Refspec.SOCIAL_LOG;
   const reached = yield* held;
-  const parents = yield* Dag.reachable(to, current, (commit) => added(commit, reached)).pipe(
+  const parents = yield* Dag.reachable(to, current, (commit) =>
+    social
+      ? reached.has(commit)
+        ? Effect.succeed(false)
+        : SocialLog.isSocialCommit(commit)
+      : added(commit, reached),
+  ).pipe(
     // An unreadable history is not a signature claim. It is refused, or passed
     // over, by the walks that own that question.
     Effect.catchTag("ObjectNotFound", () => Effect.succeed(null)),
@@ -1052,8 +1250,9 @@ const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
   if (parents === null) return null;
 
   for (const oid of parents.keys()) {
-    if (!(yield* Record.carries(oid, Event.RECORD))) continue;
-    const record = yield* Record.read(oid, Event.RECORD).pipe(
+    const recordName = social ? SocialLog.RECORD : Event.RECORD;
+    if (!(yield* Record.carries(oid, recordName))) continue;
+    const record = yield* Record.read(oid, recordName).pipe(
       Effect.catchTags({
         ObjectNotFound: () => Effect.succeed(null),
         Invalid: () => Effect.succeed(null),
@@ -1061,7 +1260,15 @@ const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
     );
     if (record === null) continue;
     const signed = yield* Verify.signers(record.payload, record.signatures);
-    const payload = yield* Event.decode(record.payload).pipe(Effect.orElseSucceed(() => null));
+    const kind = social
+      ? yield* Statement.decode(record.payload).pipe(
+          Effect.map((payload) => payload.type),
+          Effect.orElseSucceed(() => null),
+        )
+      : yield* Event.decode(record.payload).pipe(
+          Effect.map((payload) => payload.type),
+          Effect.orElseSucceed(() => null),
+        );
 
     // Every event, without an exemption list. Three attempts at one — first
     // "grants authority", then "moves authority", then a list of families —
@@ -1081,7 +1288,7 @@ const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
     // what it cannot do is arrive by push.
     for (const signer of signed) {
       if (openWindow(trust.revoked.get(signer)) !== null) {
-        return `${signer} has been revoked and may not add a ${payload?.type ?? "event"}`;
+        return `${signer} has been revoked and may not add a ${kind ?? (social ? "statement" : "event")}`;
       }
     }
 
@@ -1109,7 +1316,7 @@ const signedByRevoked = Effect.fn("Policy.signedByRevoked")(function* (
     // which `Event.decode` reads as nothing at all — so this gate covered
     // `refs/hub/pr/*` and left the two namespaces whose records are prompts,
     // the ones most likely to need removing, ungated.
-    if (!(yield* Tombstone.claims(record.payload))) continue;
+    if (social || !(yield* Tombstone.claims(record.payload))) continue;
     // Expiry as well as the capability. A permanent verdict does not consult
     // expiry — it cannot, or the answer would move on a wall clock and the
     // host that acted on it would fold a history no replica agrees with — so
@@ -1158,7 +1365,8 @@ const orphanBeyond = Effect.fn("Policy.orphanBeyond")(function* (
   // event commit off a source commit and pin everything behind it out of
   // reach of `gc` for good.
   const hub = name.startsWith("refs/hub/");
-  const belongs = hub ? Event.isHubCommit : Log.isTrustCommit;
+  const social = name === Refspec.SOCIAL_LOG;
+  const belongs = hub ? Event.isHubCommit : social ? SocialLog.isSocialCommit : Log.isTrustCommit;
   // The commit a trust log hangs off is not a record and never will be: it is
   // the genesis, the one legitimate edge out of that namespace. On every push
   // but the log's first it is already reachable from `current`; on the first
@@ -1321,10 +1529,47 @@ const protectedBranch = Effect.fn("Policy.protectedBranch")(function* (input: {
     // pull requests can propose the same revision, and refusing on the first
     // that falls short would let an unapproved duplicate block the approved
     // one purely by sorting first.
-    if (approvals(pullRequest).length < rules.requiredApprovals) {
+    const internalApprovals = approvals(pullRequest);
+    let approvalCount = internalApprovals.length;
+    const configuredExternal = rules.externalReview ?? null;
+    const externalRule = configuredExternal?.branch === input.ref ? configuredExternal : null;
+    if (
+      approvalCount < rules.requiredApprovals &&
+      externalRule !== null &&
+      externalRule.maxCount > 0
+    ) {
+      const web = yield* Effect.serviceOption(SocialProjection.SocialWeb);
+      if (Option.isSome(web)) {
+        const logs = yield* web.value.logs;
+        const external = yield* externalReviews(input.genesis, pullRequest, id, {
+          maxIdentityAgeMs: rules.maxTrustAgeSeconds * 1000,
+        });
+        const eligible = eligibleExternalApprovals({
+          rule: externalRule,
+          logs,
+          reviews: external.reviews,
+          internal: internalApprovals,
+        });
+        const graph = SocialProjection.project({
+          roots: externalRule.anchors,
+          logs,
+          maxDepth: externalRule.maxDepth,
+        });
+        const freshness =
+          rules.maxTrustAgeSeconds <= 0
+            ? ({ ok: true } as const)
+            : SocialProjection.fresh(graph, rules.maxTrustAgeSeconds * 1000);
+        if (freshness.ok) {
+          approvalCount += eligible.length;
+        } else if (eligible.length > 0) {
+          shortfall ??= refused(input.ref, `external-review web is stale: ${freshness.reason}`);
+        }
+      }
+    }
+    if (approvalCount < rules.requiredApprovals) {
       shortfall ??= refused(
         input.ref,
-        `${id} has ${approvals(pullRequest).length} approvals of its current revision, ` +
+        `${id} has ${approvalCount} approvals of its current revision, ` +
           `and ${rules.requiredApprovals} are required`,
       );
       continue;
@@ -1405,6 +1650,7 @@ export const mayWrite = Effect.fn("Policy.mayWrite")(function* (capability: stri
 
   const requester = yield* Effect.serviceOption(Auth.Requester);
   const who = Option.getOrElse(requester, () => Auth.anonymous);
+  if (who.capabilities.includes(Auth.INBOX_SUBMIT)) return null;
   const principal = { member: who.principal, capabilities: who.capabilities };
   if (principal.member === null) return "authentication required to write refs";
   return may(principal, capability) ? null : `this needs ${capability}`;
@@ -1531,6 +1777,12 @@ export const gateWrite = Effect.fn("Policy.gateWrite")(function* (
   if (ref.startsWith("refs/meta/trust/")) {
     return "a repository's identity is established by `hub init`, not over the API";
   }
+  if (ref.startsWith("refs/social/")) {
+    return `${ref} may only be appended to by a social operation`;
+  }
+  if (ref.startsWith("refs/quarantine/")) {
+    return `${ref} may only be written by a quarantine operation`;
+  }
   if (Refspec.isAppendOnly(ref)) return `${ref} may only be appended to by the hub`;
 
   const stored = yield* readGenesis();
@@ -1608,6 +1860,10 @@ export const gateWrite = Effect.fn("Policy.gateWrite")(function* (
     const trust = yield* membership(stored.genesis, who.projection);
     const stale = Verify.fresh(trust, rules.maxTrustAgeSeconds * 1000);
     if (!stale.ok) return stale.reason;
+    if (who.identity !== undefined) {
+      const foreign = Verify.fresh(who.identity.projection, rules.maxTrustAgeSeconds * 1000);
+      if (!foreign.ok) return `the member's identity view is stale: ${foreign.reason}`;
+    }
   }
 
   // Refused outright, not evaluated. Every caller of this gates by ref *name*
@@ -1747,10 +2003,23 @@ export const gate = Effect.fn("Policy.gate")(function* (
   // itself: a replica serving a consistent history that stops short of a
   // revocation. Off unless a repository asks for it, because a bound nobody
   // configured would refuse every push on a repository that never checkpoints.
-  const stale =
+  const ownStale =
     trust === null || rules.maxTrustAgeSeconds <= 0
       ? null
       : Verify.fresh(trust, rules.maxTrustAgeSeconds * 1000);
+  const identityStale =
+    rules.maxTrustAgeSeconds <= 0 || who.identity === undefined
+      ? null
+      : Verify.fresh(who.identity.projection, rules.maxTrustAgeSeconds * 1000);
+  const stale =
+    ownStale !== null && !ownStale.ok
+      ? ownStale
+      : identityStale !== null && !identityStale.ok
+        ? {
+            ok: false as const,
+            reason: `the member's identity view is stale: ${identityStale.reason}`,
+          }
+        : ownStale;
   // Refused per ref rather than for the batch, so the two refs that lift the
   // bound are still reachable while it holds; see `boundApplies`.
   const withheld = new Set(
@@ -1786,8 +2055,11 @@ export const gate = Effect.fn("Policy.gate")(function* (
   // session was thrown away and the branch landed with a trailer pointing at
   // a record the repository does not hold.
   const order = [...updates.keys()].sort((left, right) => {
-    const first = Session.sessionOf(updates[left]!.name) === null ? 1 : 0;
-    const second = Session.sessionOf(updates[right]!.name) === null ? 1 : 0;
+    const leftUpdate = updates[left];
+    const rightUpdate = updates[right];
+    if (leftUpdate === undefined || rightUpdate === undefined) return left - right;
+    const first = Session.sessionOf(leftUpdate.name) === null ? 1 : 0;
+    const second = Session.sessionOf(rightUpdate.name) === null ? 1 : 0;
     return first - second || left - right;
   });
 
@@ -1796,7 +2068,8 @@ export const gate = Effect.fn("Policy.gate")(function* (
   const mentions: MentionCache = new Map();
   const opening: Openings = new Set();
   for (const at of order) {
-    const update = updates[at]!;
+    const update = updates[at];
+    if (update === undefined) continue;
     // A native client signed an envelope naming the refs it was moving and
     // where to. Checking it here rather than in the guard is not a weakening:
     // the guard runs before the push body exists, so this is the first moment

--- a/src/server/Replication.test.ts
+++ b/src/server/Replication.test.ts
@@ -11,12 +11,15 @@ import { Repository } from "../git/Repository.ts";
 import * as Event from "../hub/Event.ts";
 import { project } from "../hub/Projection.ts";
 import * as PullRequest from "../hub/PullRequest.ts";
+import * as SocialLog from "../social/Log.ts";
+import * as Statement from "../social/Statement.ts";
 import * as Certificate from "../trust/Certificate.ts";
 import { create, signGenesis, writeGenesis } from "../trust/Genesis.ts";
 import * as Log from "../trust/Log.ts";
+import { principalId } from "../trust/Principal.ts";
 import { project as projectTrust } from "../trust/Projection.ts";
 import * as Policy from "./Policy.ts";
-import { reconcile } from "./Replication.ts";
+import { reconcile, stateFetchPasses } from "./Replication.ts";
 
 const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
   Effect.runPromise(
@@ -56,6 +59,13 @@ const world = Effect.fn("test.world")(function* () {
 });
 
 describe("Replication", () => {
+  it("fetches trust and policy before social state, then hub events", () => {
+    assert.deepEqual(
+      stateFetchPasses.map((pass) => pass.map((spec) => spec.source)),
+      [["refs/meta/trust/*", "refs/meta/policy"], ["refs/social/log"], ["refs/hub/*"]],
+    );
+  });
+
   it("joins two divergent histories of one pull request", async () => {
     const outcome = await scenario(
       Effect.gen(function* () {
@@ -270,6 +280,51 @@ describe("Replication", () => {
     // The developer from `world`, plus both concurrently granted members:
     // neither grant may be lost by the join.
     assert.equal(outcome, 3);
+  });
+
+  it("joins two divergent social logs without losing either statement", async () => {
+    const outcome = await scenario(
+      Effect.gen(function* () {
+        const repository = yield* Repository;
+        const where = yield* world();
+        const trust = yield* projectTrust(where.genesis);
+        const principal = principalId(where.genesis.repoId);
+        const context = (petname: string, socialHead: string | null) =>
+          Statement.follow({
+            author: principal,
+            subject: principal,
+            id: SocialLog.newId(),
+            socialHead,
+            trustHead: trust.head,
+            petname,
+          });
+
+        yield* SocialLog.issue(context("shared", null), where.dev);
+        const shared = yield* repository.resolve(SocialLog.LOG_REF);
+        assert.ok(shared);
+        yield* SocialLog.issue(context("ours", shared), where.dev);
+        const ours = yield* repository.resolve(SocialLog.LOG_REF);
+        assert.ok(ours);
+
+        yield* repository.setRef({ name: SocialLog.LOG_REF, to: shared, expected: ours });
+        yield* SocialLog.issue(context("theirs", shared), where.dev);
+        const theirs = yield* repository.resolve(SocialLog.LOG_REF);
+        assert.ok(theirs);
+        yield* repository.setRef({ name: SocialLog.LOG_REF, to: ours, expected: theirs });
+
+        const divergence = yield* reconcile(SocialLog.LOG_REF, theirs);
+        const log = yield* SocialLog.verified(where.genesis, trust);
+        return {
+          divergence,
+          petnames: log.statements.flatMap((entry) =>
+            entry.payload.type === "social.follow" ? [entry.payload.petname] : [],
+          ),
+        };
+      }),
+    );
+
+    assert.notEqual(outcome.divergence.joined, null);
+    assert.deepEqual([...outcome.petnames].sort(), ["ours", "shared", "theirs"]);
   });
 
   it("takes the source's rules file rather than reporting it as a divergence", async () => {

--- a/src/server/Replication.ts
+++ b/src/server/Replication.ts
@@ -30,6 +30,7 @@ import * as Policy from "./Policy.ts";
 import { Repository } from "../git/Repository.ts";
 import type { Oid } from "../git/Store.ts";
 import * as Event from "../hub/Event.ts";
+import * as SocialLog from "../social/Log.ts";
 import * as Log from "../trust/Log.ts";
 
 export interface Divergence {
@@ -60,6 +61,16 @@ export interface Outcome {
   readonly rejected: ReadonlyArray<{ readonly name: string; readonly oid: Oid }>;
 }
 
+/** Ordered state passes: authority first, then social evidence, then consumers. */
+export const stateFetchPasses: ReadonlyArray<ReadonlyArray<Refspec.Refspec>> = [
+  [
+    { force: false, source: "refs/meta/trust/*", destination: "refs/meta/trust/*" },
+    { force: false, source: "refs/meta/policy", destination: "refs/meta/policy" },
+  ],
+  [{ force: false, source: Refspec.SOCIAL_LOG, destination: Refspec.SOCIAL_LOG }],
+  [{ force: false, source: "refs/hub/*", destination: "refs/hub/*" }],
+];
+
 /**
  * Fetch trust, then hub, from one remote.
  *
@@ -80,26 +91,16 @@ export const pull = Effect.fn("Replication.pull")(function* (input: {
   // replica holding the membership but not the rules answers `OPEN` to every
   // question the policy boundary asks, so it would let through exactly the
   // pushes the origin protects.
-  const trust = yield* fetchRepository({
-    url: input.url,
-    stores: input.stores,
-    token: input.token,
-    refspecs: [
-      { force: false, source: "refs/meta/trust/*", destination: "refs/meta/trust/*" },
-      { force: false, source: "refs/meta/policy", destination: "refs/meta/policy" },
-    ],
-  });
-  fetched.push(...trust.refs.map((update) => update.name));
-  rejected.push(...trust.rejected);
-
-  const hub = yield* fetchRepository({
-    url: input.url,
-    stores: input.stores,
-    token: input.token,
-    refspecs: [{ force: false, source: "refs/hub/*", destination: "refs/hub/*" }],
-  });
-  fetched.push(...hub.refs.map((update) => update.name));
-  rejected.push(...hub.rejected);
+  for (const refspecs of stateFetchPasses) {
+    const pass = yield* fetchRepository({
+      url: input.url,
+      stores: input.stores,
+      token: input.token,
+      refspecs,
+    });
+    fetched.push(...pass.refs.map((update) => update.name));
+    rejected.push(...pass.rejected);
+  }
 
   if (input.includeSource === true) {
     const source = yield* fetchRepository({
@@ -203,7 +204,7 @@ const joinInto = Effect.fn("Replication.joinInto")(function* (
   heads: ReadonlyArray<Oid>,
 ) {
   const repository = yield* Repository;
-  const commit = yield* Log.join(heads);
+  const commit = ref === Refspec.SOCIAL_LOG ? yield* SocialLog.join(heads) : yield* Log.join(heads);
   yield* repository.setRef({ name: ref, to: commit, expected: heads[0] ?? null });
   return commit;
 });

--- a/src/social/Encode.test.ts
+++ b/src/social/Encode.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Result } from "effect";
+
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId } from "../trust/Principal.ts";
+import { decodeIdentifier, encodePrincipal, encodeRepository } from "./Encode.ts";
+
+/** SAFETY: forty-three base64 characters after `SHA256:`, which is the shape. */
+const repo = (seed: string): RepoId => {
+  // SAFETY: forty-three base64 characters with canonical zero padding bits in
+  // the final character, matching a real SHA-256 digest's unpadded encoding.
+  return `SHA256:${seed.repeat(42).slice(0, 42)}A` as RepoId;
+};
+
+const value = <A, E>(result: Result.Result<A, E>): A => {
+  assert.ok(Result.isSuccess(result));
+  return result.success;
+};
+
+describe("shareable identifiers", () => {
+  it.effect("round-trips a typed PrincipalID with bootstrap-only location hints", () =>
+    Effect.sync(() => {
+      const id = principalId(repo("a"));
+      const encoded = value(
+        encodePrincipal({
+          id,
+          hints: ["https://git.alice.example/id", "https://mirror.example/alice"],
+        }),
+      );
+
+      assert.match(encoded, /^gid1/);
+      assert.deepEqual(value(decodeIdentifier(encoded)), {
+        kind: "principal",
+        id,
+        hints: ["https://git.alice.example/id", "https://mirror.example/alice"],
+      });
+    }),
+  );
+
+  it.effect("keeps repository and principal identifiers type-distinct", () =>
+    Effect.sync(() => {
+      const id = repo("b");
+      const encoded = value(encodeRepository({ id, hints: [] }));
+      const decoded = value(decodeIdentifier(encoded));
+
+      assert.match(encoded, /^grepo1/);
+      assert.equal(decoded.kind, "repository");
+      assert.equal(decoded.id, id);
+    }),
+  );
+
+  it.effect("detects a one-character transcription error", () =>
+    Effect.sync(() => {
+      const encoded = value(encodeRepository({ id: repo("c"), hints: [] }));
+      const last = encoded.at(-1);
+      if (last === undefined) assert.fail("encoded identifiers cannot be empty");
+      const corrupted = `${encoded.slice(0, -1)}${last === "q" ? "p" : "q"}`;
+      const decoded = decodeIdentifier(corrupted);
+
+      assert.ok(Result.isFailure(decoded));
+      assert.match(decoded.failure.reason, /checksum/);
+    }),
+  );
+
+  it.effect("bounds the bootstrap data carried in an identifier", () =>
+    Effect.sync(() => {
+      const encoded = encodeRepository({
+        id: repo("d"),
+        hints: [
+          "https://a.example",
+          "https://b.example",
+          "https://c.example",
+          "https://d.example",
+          "https://e.example",
+        ],
+      });
+      assert.ok(Result.isFailure(encoded));
+      assert.match(encoded.failure.reason, /at most four/i);
+    }),
+  );
+});

--- a/src/social/Encode.ts
+++ b/src/social/Encode.ts
@@ -1,0 +1,180 @@
+/** Typed bech32m encodings for PrincipalIDs and RepoIDs. */
+import { Result } from "effect";
+
+import { Invalid } from "../git/Error.ts";
+import { isRepoId, type RepoId } from "../trust/Genesis.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+
+const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32M = 0x2bc830a3;
+const generators = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+const text = new TextEncoder();
+const decoder = new TextDecoder();
+
+const invalid = (reason: string) => Result.fail(new Invalid({ field: "identifier", reason }));
+
+const polymod = (values: ReadonlyArray<number>): number => {
+  let checksum = 1;
+  for (const value of values) {
+    const top = checksum >>> 25;
+    checksum = (((checksum & 0x1ffffff) << 5) ^ value) >>> 0;
+    for (let bit = 0; bit < 5; bit++) {
+      const generator = generators[bit];
+      if (generator !== undefined && ((top >>> bit) & 1) !== 0) {
+        checksum = (checksum ^ generator) >>> 0;
+      }
+    }
+  }
+  return checksum >>> 0;
+};
+
+const expand = (hrp: string): ReadonlyArray<number> => [
+  ...[...hrp].map((character) => character.charCodeAt(0) >>> 5),
+  0,
+  ...[...hrp].map((character) => character.charCodeAt(0) & 31),
+];
+
+const checksum = (hrp: string, words: ReadonlyArray<number>): ReadonlyArray<number> => {
+  const value = (polymod([...expand(hrp), ...words, 0, 0, 0, 0, 0, 0]) ^ BECH32M) >>> 0;
+  return Array.from({ length: 6 }, (_, index) => (value >>> (5 * (5 - index))) & 31);
+};
+
+const convertBits = (
+  values: ReadonlyArray<number>,
+  from: number,
+  to: number,
+  pad: boolean,
+): ReadonlyArray<number> | null => {
+  let accumulator = 0;
+  let bits = 0;
+  const result: number[] = [];
+  const maximum = (1 << to) - 1;
+  const fromMaximum = (1 << from) - 1;
+  for (const value of values) {
+    if (value < 0 || value >>> from !== 0) return null;
+    accumulator = ((accumulator << from) | (value & fromMaximum)) >>> 0;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      result.push((accumulator >>> bits) & maximum);
+    }
+  }
+  if (pad) {
+    if (bits > 0) result.push((accumulator << (to - bits)) & maximum);
+  } else if (bits >= from || ((accumulator << (to - bits)) & maximum) !== 0) {
+    return null;
+  }
+  return result;
+};
+
+const idBytes = (id: RepoId): Uint8Array => {
+  const encoded = id.slice("SHA256:".length);
+  const binary = atob(`${encoded}=`);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+};
+
+const idOf = (bytes: ReadonlyArray<number>): RepoId | null => {
+  if (bytes.length !== 32) return null;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const value = `SHA256:${btoa(binary).replace(/=+$/, "")}`;
+  return isRepoId(value) ? value : null;
+};
+
+const validHint = (hint: string): boolean => {
+  try {
+    const url = new URL(hint);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const encode = (
+  hrp: "gid" | "grepo",
+  id: RepoId,
+  hints: ReadonlyArray<string>,
+): Result.Result<string, Invalid> => {
+  if (hints.length > 4) return invalid("an identifier carries at most four location hints");
+
+  const payload: number[] = [0, 32, ...idBytes(id)];
+  for (const hint of hints) {
+    if (!validHint(hint)) return invalid(`'${hint}' is not an HTTP URL`);
+    const bytes = text.encode(hint);
+    if (bytes.length > 255) return invalid("a location hint may be at most 255 bytes");
+    payload.push(1, bytes.length, ...bytes);
+  }
+
+  const words = convertBits(payload, 8, 5, true);
+  if (words === null) return invalid("identifier payload could not be encoded");
+  const values = [...words, ...checksum(hrp, words)];
+  return Result.succeed(`${hrp}1${values.map((value) => CHARSET[value]).join("")}`);
+};
+
+export const encodePrincipal = (input: {
+  readonly id: PrincipalId;
+  readonly hints?: ReadonlyArray<string>;
+}): Result.Result<string, Invalid> => encode("gid", input.id, input.hints ?? []);
+
+export const encodeRepository = (input: {
+  readonly id: RepoId;
+  readonly hints?: ReadonlyArray<string>;
+}): Result.Result<string, Invalid> => encode("grepo", input.id, input.hints ?? []);
+
+export type DecodedIdentifier =
+  | { readonly kind: "principal"; readonly id: PrincipalId; readonly hints: ReadonlyArray<string> }
+  | { readonly kind: "repository"; readonly id: RepoId; readonly hints: ReadonlyArray<string> };
+
+export const decodeIdentifier = (encoded: string): Result.Result<DecodedIdentifier, Invalid> => {
+  if (encoded.length > 2048) return invalid("identifier is too long");
+  if (encoded !== encoded.toLowerCase() && encoded !== encoded.toUpperCase()) {
+    return invalid("identifier mixes letter case");
+  }
+  const source = encoded.toLowerCase();
+  const separator = source.lastIndexOf("1");
+  if (separator <= 0 || separator + 7 > source.length) return invalid("identifier is not bech32m");
+  const hrp = source.slice(0, separator);
+  if (hrp !== "gid" && hrp !== "grepo") return invalid(`unknown identifier type '${hrp}'`);
+
+  const values: number[] = [];
+  for (const character of source.slice(separator + 1)) {
+    const value = CHARSET.indexOf(character);
+    if (value === -1) return invalid(`'${character}' is not a bech32 character`);
+    values.push(value);
+  }
+  if (polymod([...expand(hrp), ...values]) !== BECH32M) {
+    return invalid("identifier checksum does not match");
+  }
+
+  const bytes = convertBits(values.slice(0, -6), 5, 8, false);
+  if (bytes === null) return invalid("identifier has invalid bit padding");
+
+  let id: RepoId | null = null;
+  const hints: string[] = [];
+  for (let at = 0; at < bytes.length;) {
+    const type = bytes[at++];
+    const length = bytes[at++];
+    if (type === undefined || length === undefined || at + length > bytes.length) {
+      return invalid("identifier has a truncated TLV field");
+    }
+    const value = bytes.slice(at, at + length);
+    at += length;
+    if (type === 0) {
+      if (id !== null) return invalid("identifier carries more than one identity");
+      id = idOf(value);
+      if (id === null) return invalid("identifier carries a malformed SHA-256 identity");
+      continue;
+    }
+    if (type === 1) {
+      const hint = decoder.decode(Uint8Array.from(value));
+      if (!validHint(hint)) return invalid("identifier carries a malformed location hint");
+      hints.push(hint);
+    }
+  }
+  if (id === null) return invalid("identifier carries no identity");
+  if (hints.length > 4) return invalid("identifier carries more than four location hints");
+
+  return hrp === "gid"
+    ? Result.succeed({ kind: "principal", id: principalId(id), hints })
+    : Result.succeed({ kind: "repository", id, hints });
+};

--- a/src/social/Inbox.test.ts
+++ b/src/social/Inbox.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { formatPublicKey, generate } from "../crypto/SshSignature.ts";
+import { EMPTY_TREE_OID, type Signature } from "../git/Format.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import * as Event from "../hub/Event.ts";
+import { project as projectPullRequest } from "../hub/Projection.ts";
+import * as Certificate from "../trust/Certificate.ts";
+import { create, signGenesis, writeGenesis } from "../trust/Genesis.ts";
+import * as Log from "../trust/Log.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import { adopt, pending, submit } from "./Inbox.ts";
+
+const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        GitRepository.layer.pipe(
+          Layer.provide(GitRepository.hooksNoop),
+          Layer.provideMerge(stores),
+        ),
+      ),
+    ),
+  );
+
+const author: Signature = {
+  name: "Drive-by contributor",
+  email: "stranger@example.com",
+  at: new Date("2026-08-20T00:00:00Z"),
+  offset: 0,
+};
+
+describe("social inbox", () => {
+  it.effect("keeps an anonymous proposal quarantined until a member adopts it", () =>
+    Effect.promise(async () => {
+      const outcome = await scenario(
+        Effect.gen(function* () {
+          const repository = yield* Repository;
+          const root = yield* generate("root@example.com");
+          const maintainer = yield* generate("maintainer@example.com");
+          const outsider = yield* generate("outsider@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(maintainer.publicKey),
+              capabilities: ["hub.create-pr"],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const proposal = yield* repository.commit({
+            branch: "refs/heads/stranger-patch",
+            tree: EMPTY_TREE_OID,
+            message: "drive-by patch",
+            author,
+          });
+
+          const offered = yield* submit({
+            repo: genesis.repoId,
+            head: proposal,
+            base: "refs/heads/main",
+            title: "Fix from a stranger",
+            description: "Please consider this patch.",
+          });
+          const before = yield* pending();
+          const beforePulls = yield* Event.pullRequests();
+          const trust = yield* projectTrust(genesis);
+          const denied = yield* Effect.exit(
+            adopt({ genesis, trust, proposal: offered.id, key: outsider }),
+          );
+          const adopted = yield* adopt({
+            genesis,
+            trust,
+            proposal: offered.id,
+            key: maintainer,
+          });
+          const state = yield* projectPullRequest(genesis, trust, adopted.pr);
+
+          return { before, beforePulls, denied, after: yield* pending(), state, proposal };
+        }),
+      );
+
+      assert.equal(outcome.before.length, 1);
+      assert.deepEqual(outcome.beforePulls, [], "quarantine contributes no hub event");
+      assert.equal(outcome.denied._tag, "Failure");
+      assert.equal(outcome.after.length, 0, "an adopted proposal leaves the pending queue");
+      assert.equal(outcome.state.head, outcome.proposal);
+    }),
+  );
+});

--- a/src/social/Inbox.ts
+++ b/src/social/Inbox.ts
@@ -1,0 +1,219 @@
+/** A host-local quarantine for contributions from callers without membership. */
+import { Effect, Schema } from "effect";
+
+import { fingerprint, type PrivateKey } from "../crypto/SshSignature.ts";
+import { Invalid } from "../git/Error.ts";
+import { Repository } from "../git/Repository.ts";
+import { isOid, type Oid } from "../git/Store.ts";
+import * as Event from "../hub/Event.ts";
+import * as PullRequest from "../hub/PullRequest.ts";
+import { isRepoId, readGenesis, type Genesis, type RepoId } from "../trust/Genesis.ts";
+import * as Log from "../trust/Log.ts";
+import type { Projection as TrustProjection } from "../trust/Projection.ts";
+import * as Record from "../trust/Record.ts";
+import * as Verify from "../trust/Verify.ts";
+
+export const PENDING_PREFIX = "refs/quarantine/inbox/";
+export const ADOPTED_PREFIX = "refs/quarantine/adopted/";
+export const RECORD = "proposal";
+
+const ProposalDocument = Schema.Struct({
+  version: Schema.Literal(1),
+  id: Schema.String,
+  repo: Schema.String,
+  head: Schema.String,
+  base: Schema.String,
+  title: Schema.String,
+  description: Schema.String,
+  submittedAt: Schema.String,
+});
+
+type ProposalDocument = (typeof ProposalDocument)["Type"];
+
+export interface Proposal {
+  readonly id: string;
+  readonly repo: RepoId;
+  readonly head: Oid;
+  readonly base: string;
+  readonly title: string;
+  readonly description: string;
+  readonly submittedAt: Date;
+  readonly commit: Oid;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const decodeDocument = Schema.decodeUnknownEffect(ProposalDocument);
+
+const refOf = (id: string): string => `${PENDING_PREFIX}${id}`;
+const adoptedRefOf = (id: string): string => `${ADOPTED_PREFIX}${id}`;
+
+/** UUIDv7 names keep unauthenticated submissions bounded to one flat ref component. */
+export const isProposalId = (id: string): boolean =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(id) &&
+  Event.isPullRequestId(id);
+
+const validateId = (id: string): Effect.Effect<string, Invalid> =>
+  isProposalId(id)
+    ? Effect.succeed(id)
+    : Effect.fail(new Invalid({ field: "id", reason: `'${id}' cannot name an inbox proposal` }));
+
+const decode = Effect.fn("social.Inbox.decode")(function* (commit: Oid, fallbackId?: string) {
+  const record = yield* Record.read(commit, RECORD).pipe(
+    Effect.catchTags({
+      Invalid: () => Effect.succeed(null),
+      ObjectNotFound: () => Effect.succeed(null),
+    }),
+  );
+  if (record === null) {
+    if (fallbackId === undefined) {
+      return yield* new Invalid({ field: "proposal", reason: "proposal metadata is missing" });
+    }
+    yield* validateId(fallbackId);
+    const stored = yield* readGenesis();
+    if (stored === null) {
+      return yield* new Invalid({ field: "repo", reason: "the inbox has no repository identity" });
+    }
+    const repository = yield* Repository;
+    const info = yield* repository.readCommit(commit);
+    const configuredHead = yield* repository.head;
+    const base = configuredHead.startsWith("refs/heads/") ? configuredHead : "refs/heads/main";
+    const message = info.message.trim();
+    const title = (message.split("\n")[0] ?? "Inbox proposal").slice(0, 256);
+    return {
+      id: fallbackId,
+      repo: stored.genesis.repoId,
+      head: commit,
+      base,
+      title,
+      description: message.slice(0, 16_384),
+      submittedAt: info.author.at,
+      commit,
+    } satisfies Proposal;
+  }
+  const json = yield* Effect.try({
+    try: () => JSON.parse(decoder.decode(record.payload)),
+    catch: () => new Invalid({ field: "proposal", reason: "proposal is not valid JSON" }),
+  });
+  const document = yield* decodeDocument(json).pipe(
+    Effect.mapError(
+      (issue) => new Invalid({ field: "proposal", reason: `malformed proposal: ${issue.message}` }),
+    ),
+  );
+  yield* validateId(document.id);
+  if (!isRepoId(document.repo)) {
+    return yield* new Invalid({ field: "repo", reason: `'${document.repo}' is not a RepoID` });
+  }
+  if (!isOid(document.head)) {
+    return yield* new Invalid({ field: "head", reason: `'${document.head}' is not an object id` });
+  }
+  if (!document.base.startsWith("refs/heads/")) {
+    return yield* new Invalid({
+      field: "base",
+      reason: "proposal base must be a refs/heads/* ref",
+    });
+  }
+  const submittedAt = new Date(document.submittedAt);
+  if (Number.isNaN(submittedAt.getTime())) {
+    return yield* new Invalid({ field: "submittedAt", reason: "proposal date is invalid" });
+  }
+  return { ...document, repo: document.repo, head: document.head, submittedAt, commit };
+});
+
+/** Store one proposal without adding anything to the hub projection. */
+export const submit = Effect.fn("social.Inbox.submit")(function* (input: {
+  readonly repo: RepoId;
+  readonly head: Oid;
+  readonly base: string;
+  readonly title: string;
+  readonly description?: string;
+  readonly id?: string;
+}) {
+  const repository = yield* Repository;
+  const genesis = yield* readGenesis();
+  if (genesis === null || genesis.genesis.repoId !== input.repo) {
+    return yield* new Invalid({ field: "repo", reason: "proposal targets another repository" });
+  }
+  yield* repository.readCommit(input.head);
+  const id = yield* validateId(input.id ?? Log.newId());
+  if ((yield* repository.resolve(adoptedRefOf(id))) !== null) {
+    return yield* new Invalid({ field: "proposal", reason: `'${id}' was already adopted` });
+  }
+  const base = Event.branchRef(input.base);
+  const document: ProposalDocument = {
+    version: 1,
+    id,
+    repo: input.repo,
+    head: input.head,
+    base,
+    title: input.title,
+    description: input.description ?? "",
+    submittedAt: new Date().toISOString(),
+  };
+  const commit = yield* Record.write({
+    name: RECORD,
+    payload: encoder.encode(`${JSON.stringify(document, null, 2)}\n`),
+    signatures: [],
+    parents: [input.head],
+    message: `quarantined proposal ${id}\n`,
+  });
+  yield* repository.setRef({ name: refOf(id), to: commit, expected: null });
+  return yield* decode(commit);
+});
+
+export const read = Effect.fn("social.Inbox.read")(function* (id: string) {
+  yield* validateId(id);
+  const repository = yield* Repository;
+  const commit = yield* repository.resolve(refOf(id));
+  if (commit === null) {
+    return yield* new Invalid({ field: "proposal", reason: `no pending proposal '${id}'` });
+  }
+  return yield* decode(commit, id);
+});
+
+export const pending = Effect.fn("social.Inbox.pending")(function* () {
+  const repository = yield* Repository;
+  const proposals: Proposal[] = [];
+  for (const [ref, commit] of yield* repository.refs) {
+    if (!ref.startsWith(PENDING_PREFIX)) continue;
+    const id = ref.slice(PENDING_PREFIX.length);
+    if ((yield* repository.resolve(adoptedRefOf(id))) !== null) continue;
+    proposals.push(yield* decode(commit, id));
+  }
+  return proposals.sort((left, right) => left.id.localeCompare(right.id));
+});
+
+/** Promote a quarantined proposal under a member's own signed opening event. */
+export const adopt = Effect.fn("social.Inbox.adopt")(function* (input: {
+  readonly genesis: Genesis;
+  readonly trust: TrustProjection;
+  readonly proposal: string;
+  readonly key: PrivateKey;
+}) {
+  const proposal = yield* read(input.proposal);
+  if (proposal.repo !== input.genesis.repoId || input.trust.repoId !== input.genesis.repoId) {
+    return yield* new Invalid({ field: "repo", reason: "proposal and trust projection disagree" });
+  }
+  const signer = yield* fingerprint(input.key.publicKey);
+  const authorized = yield* Verify.authorizeKey({
+    projection: input.trust,
+    signer,
+    capability: "hub.create-pr",
+  });
+  if (!authorized.ok) {
+    return yield* new Invalid({ field: "authorization", reason: authorized.reason });
+  }
+
+  const opened = yield* PullRequest.open({
+    repo: input.genesis.repoId,
+    title: proposal.title,
+    description: proposal.description,
+    base: proposal.base,
+    head: proposal.head,
+    key: input.key,
+  });
+  const repository = yield* Repository;
+  yield* repository.setRef({ name: adoptedRefOf(proposal.id), to: opened.commit, expected: null });
+  yield* repository.deleteRef(refOf(proposal.id));
+  return opened;
+});

--- a/src/social/Introduce.test.ts
+++ b/src/social/Introduce.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect } from "effect";
+
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import type { Oid } from "../git/Store.ts";
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+import { decide, repositories } from "./Introduce.ts";
+import type { VerifiedLog, VerifiedStatement } from "./Log.ts";
+import { project } from "./Projection.ts";
+import { attestRepo, encode, vouch, type SocialStatement } from "./Statement.ts";
+
+/** SAFETY: forty-three base64 characters after `SHA256:`, which is the shape. */
+const repo = (seed: string): RepoId => `SHA256:${seed.repeat(43).slice(0, 43)}` as RepoId;
+const principal = (seed: string): PrincipalId => principalId(repo(seed));
+const alice = principal("a");
+const bob = principal("b");
+const carol = principal("c");
+const projectRepo = repo("p");
+const impostor = repo("x");
+const url = "https://git.example.com/acme/project";
+
+const oid = (value: number): Oid => {
+  // SAFETY: exactly forty lowercase hexadecimal characters.
+  return value.toString(16).padStart(40, "0") as Oid;
+};
+
+const entry = (payload: SocialStatement, index: number): VerifiedStatement => ({
+  commit: oid(index),
+  parents: index === 1 ? [] : [oid(index - 1)],
+  payload,
+  bytes: encode(payload),
+  signatures: [],
+  // SAFETY: forty-three base64 characters after the prefix.
+  signer: `SHA256:${payload.author.slice(-1).repeat(43)}` as Fingerprint,
+});
+
+const log = (owner: PrincipalId, statements: ReadonlyArray<SocialStatement>): VerifiedLog => ({
+  principal: owner,
+  head: statements.length === 0 ? null : oid(statements.length),
+  statements: statements.map(entry),
+  rejected: [],
+});
+
+const context = (author: PrincipalId, index: number) => ({
+  author,
+  id: `018bcfe5-6800-7000-8000-${index.toString().padStart(12, "0")}`,
+  socialHead: index === 1 ? null : oid(index - 1),
+  trustHead: null,
+  at: new Date(`2026-08-20T00:00:0${index}Z`),
+});
+
+describe("social introduction", () => {
+  it.effect("replaces blind TOFU when enough independent attesters name the presented RepoID", () =>
+    Effect.gen(function* () {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            vouch({
+              ...context(alice, 1),
+              subject: bob,
+              scope: ["introduce.repo"],
+              depth: 0,
+            }),
+            attestRepo({
+              ...context(alice, 2),
+              repo: projectRepo,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+          log(bob, [
+            attestRepo({
+              ...context(bob, 1),
+              repo: projectRepo,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+        ],
+      });
+
+      const decision = yield* decide({
+        projection,
+        url: `${url}.git/`,
+        presented: projectRepo,
+        minPaths: 2,
+      });
+      assert.equal(decision.kind, "introduced");
+      assert.equal(decision.kind === "introduced" ? decision.paths : 0, 2);
+      assert.equal(repositories(projection)[0]?.repo, projectRepo);
+    }),
+  );
+
+  it.effect("surfaces a split view instead of picking one identity", () =>
+    Effect.gen(function* () {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            vouch({
+              ...context(alice, 1),
+              subject: bob,
+              scope: ["introduce.repo", "vouch"],
+              depth: 1,
+            }),
+            vouch({
+              ...context(alice, 2),
+              subject: carol,
+              scope: ["introduce.repo"],
+              depth: 0,
+            }),
+          ]),
+          log(bob, [
+            attestRepo({
+              ...context(bob, 1),
+              repo: projectRepo,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+          log(carol, [
+            attestRepo({
+              ...context(carol, 1),
+              repo: impostor,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+        ],
+      });
+
+      const decision = yield* decide({ projection, url, presented: projectRepo, minPaths: 1 });
+      assert.equal(decision.kind, "split");
+      assert.deepEqual(
+        decision.kind === "split" ? decision.claims.map(({ repo }) => repo).sort() : [],
+        [impostor, projectRepo].sort(),
+      );
+    }),
+  );
+
+  it.effect("surfaces one trusted claim that conflicts with the presented identity", () =>
+    Effect.gen(function* () {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            attestRepo({
+              ...context(alice, 1),
+              repo: projectRepo,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+        ],
+      });
+
+      const decision = yield* decide({ projection, url, presented: impostor });
+      assert.equal(decision.kind, "split");
+      assert.deepEqual(decision.kind === "split" ? decision.claims.map(({ repo }) => repo) : [], [
+        projectRepo,
+      ]);
+    }),
+  );
+
+  it.effect("falls back to TOFU when the verifier's own roots do not reach an attester", () =>
+    Effect.gen(function* () {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(bob, [
+            attestRepo({
+              ...context(bob, 1),
+              repo: projectRepo,
+              urls: [url],
+              role: "origin",
+            }),
+          ]),
+        ],
+      });
+      const decision = yield* decide({ projection, url, presented: projectRepo });
+      assert.equal(decision.kind, "tofu");
+    }),
+  );
+});

--- a/src/social/Introduce.ts
+++ b/src/social/Introduce.ts
@@ -1,0 +1,173 @@
+/** Web-of-trust introduction and repository discovery. */
+import { Effect } from "effect";
+
+import type { Oid } from "../git/Store.ts";
+import { isRepoId, type RepoId } from "../trust/Genesis.ts";
+import { canonicalUrl } from "../trust/KnownRepos.ts";
+import { isPrincipalId, type PrincipalId } from "../trust/Principal.ts";
+import { pathsTo, type Projection, type TrustPath } from "./Projection.ts";
+
+export interface RepositoryEvidence {
+  readonly repo: RepoId;
+  readonly url: string;
+  readonly role: "origin" | "mirror" | "fork";
+  readonly forkOf: RepoId | null;
+  readonly lineage: string | null;
+  readonly inbox: string | null;
+  readonly author: PrincipalId;
+  readonly commit: Oid;
+  readonly paths: ReadonlyArray<TrustPath>;
+}
+
+const normal = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    const path = url.pathname
+      .replace(/\/+$/, "")
+      .replace(/\.git$/, "")
+      .replace(/\/+$/, "");
+    return `${url.protocol}//${url.host}${path}`;
+  } catch {
+    return null;
+  }
+};
+
+/** Every reachable repository attestation, one row per URL. */
+export const repositories = (projection: Projection): ReadonlyArray<RepositoryEvidence> => {
+  const found: RepositoryEvidence[] = [];
+  for (const statement of projection.active) {
+    if (statement.payload.type !== "social.attest.repo") continue;
+    if (!isPrincipalId(statement.payload.author) || !isRepoId(statement.payload.repo)) continue;
+    if (statement.payload.forkOf !== null && !isRepoId(statement.payload.forkOf)) continue;
+    const paths = pathsTo(projection, statement.payload.author, "introduce.repo");
+    if (paths.length === 0) continue;
+    for (const url of statement.payload.urls) {
+      const canonical = normal(url);
+      if (canonical === null) continue;
+      found.push({
+        repo: statement.payload.repo,
+        url: canonical,
+        role: statement.payload.role,
+        forkOf: statement.payload.forkOf,
+        lineage: statement.payload.lineage,
+        inbox: statement.payload.inbox,
+        author: statement.payload.author,
+        commit: statement.commit,
+        paths,
+      });
+    }
+  }
+  return found.sort((left, right) =>
+    left.repo !== right.repo
+      ? left.repo < right.repo
+        ? -1
+        : 1
+      : left.url !== right.url
+        ? left.url < right.url
+          ? -1
+          : 1
+        : left.commit < right.commit
+          ? -1
+          : 1,
+  );
+};
+
+/**
+ * Independent evidence across different attesters.
+ *
+ * The attester is a dependency here, unlike the common subject of several
+ * paths in `Projection.confidence`: Bob's own attestation and Carol's word
+ * reached only through Bob are not two independent introductions.
+ */
+const independentEvidence = (
+  evidence: ReadonlyArray<RepositoryEvidence>,
+): ReadonlyArray<{ readonly evidence: RepositoryEvidence; readonly path: TrustPath }> => {
+  const candidates: Array<{ readonly evidence: RepositoryEvidence; readonly path: TrustPath }> = [];
+  const seen = new Set<string>();
+  for (const item of evidence) {
+    for (const path of item.paths) {
+      const key = `${item.author}\u0000${path.principals.join("\u0000")}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push({ evidence: item, path });
+    }
+  }
+  candidates.sort((left, right) =>
+    left.path.principals.length !== right.path.principals.length
+      ? left.path.principals.length - right.path.principals.length
+      : left.path.principals.join("") < right.path.principals.join("")
+        ? -1
+        : 1,
+  );
+
+  const dependencies = new Set<PrincipalId>();
+  const authors = new Set<PrincipalId>();
+  const selected: Array<{ readonly evidence: RepositoryEvidence; readonly path: TrustPath }> = [];
+  for (const candidate of candidates) {
+    if (authors.has(candidate.evidence.author)) continue;
+    const depends = candidate.path.principals.slice(1);
+    if (depends.some((principal) => dependencies.has(principal))) continue;
+    selected.push(candidate);
+    authors.add(candidate.evidence.author);
+    for (const principal of depends) dependencies.add(principal);
+  }
+  return selected;
+};
+
+export interface Claim {
+  readonly repo: RepoId;
+  readonly paths: number;
+  readonly attesters: ReadonlyArray<PrincipalId>;
+}
+
+export type Decision =
+  | { readonly kind: "tofu"; readonly repoId: RepoId }
+  | {
+      readonly kind: "introduced";
+      readonly repoId: RepoId;
+      readonly paths: number;
+      readonly attesters: ReadonlyArray<PrincipalId>;
+    }
+  | { readonly kind: "split"; readonly presented: RepoId; readonly claims: ReadonlyArray<Claim> };
+
+/** Decide a first sighting against the verifier's own rooted web. */
+export const decide = Effect.fn("social.Introduce.decide")(function* (input: {
+  readonly projection: Projection;
+  readonly url: string;
+  readonly presented: RepoId;
+  readonly minPaths?: number;
+}) {
+  const wanted = yield* canonicalUrl(input.url);
+  const matching = repositories(input.projection).filter((evidence) => evidence.url === wanted);
+  const grouped = new Map<RepoId, RepositoryEvidence[]>();
+  for (const evidence of matching) {
+    grouped.set(evidence.repo, [...(grouped.get(evidence.repo) ?? []), evidence]);
+  }
+
+  const claims: Claim[] = [];
+  for (const [repo, evidence] of grouped) {
+    const independent = independentEvidence(evidence);
+    if (independent.length === 0) continue;
+    claims.push({
+      repo,
+      paths: independent.length,
+      attesters: independent.map(({ evidence }) => evidence.author),
+    });
+  }
+  claims.sort((left, right) => (left.repo < right.repo ? -1 : 1));
+
+  const claim = claims[0];
+  if (claims.length > 1 || (claim !== undefined && claim.repo !== input.presented)) {
+    return { kind: "split", presented: input.presented, claims } as const;
+  }
+  const minPaths = Math.max(1, input.minPaths ?? 1);
+  if (claim?.repo === input.presented && claim.paths >= minPaths) {
+    return {
+      kind: "introduced",
+      repoId: input.presented,
+      paths: claim.paths,
+      attesters: claim.attesters,
+    } as const;
+  }
+  return { kind: "tofu", repoId: input.presented } as const;
+});

--- a/src/social/Lineage.test.ts
+++ b/src/social/Lineage.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { EMPTY_TREE_OID, type Signature } from "../git/Format.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import { earliestUnique } from "./Lineage.ts";
+
+const author: Signature = {
+  name: "Alice",
+  email: "alice@example.com",
+  at: new Date("2026-08-20T00:00:00Z"),
+  offset: 0,
+};
+
+const live = GitRepository.layer.pipe(
+  Layer.provide(GitRepository.hooksNoop),
+  Layer.provide(stores),
+);
+
+describe("repository lineage", () => {
+  it.effect("uses the root for an origin and the first unique commit for a fork", () =>
+    Effect.gen(function* () {
+      const repository = yield* Repository;
+      const root = yield* repository.commit({
+        branch: "refs/heads/main",
+        tree: EMPTY_TREE_OID,
+        message: "root",
+        author,
+      });
+      const upstream = yield* repository.commit({
+        branch: "refs/heads/main",
+        tree: EMPTY_TREE_OID,
+        message: "upstream",
+        author,
+      });
+      yield* repository.branch({ name: "fork", base: upstream });
+      const first = yield* repository.commit({
+        branch: "refs/heads/fork",
+        tree: EMPTY_TREE_OID,
+        message: "fork one",
+        author,
+      });
+      const head = yield* repository.commit({
+        branch: "refs/heads/fork",
+        tree: EMPTY_TREE_OID,
+        message: "fork two",
+        author,
+      });
+
+      assert.equal(yield* earliestUnique({ head: upstream }), `sha1:${root}`);
+      assert.equal(yield* earliestUnique({ head, upstream }), `sha1:${first}`);
+    }).pipe(Effect.provide(live)),
+  );
+});

--- a/src/social/Lineage.ts
+++ b/src/social/Lineage.ts
@@ -1,0 +1,72 @@
+/** Deterministic earliest-unique-commit lineage keys for repository discovery. */
+import { Effect } from "effect";
+
+import { Invalid, type ObjectNotFound, type StorageFailure } from "../git/Error.ts";
+import { Repository } from "../git/Repository.ts";
+import type { Oid } from "../git/Store.ts";
+
+export type Lineage = `sha1:${Oid}`;
+
+export const isLineage = (value: string): value is Lineage => /^sha1:[0-9a-f]{40}$/.test(value);
+
+const MAX_COMMITS = 1_000_000;
+
+const history = Effect.fn("social.Lineage.history")(function* (head: Oid, ceiling: number) {
+  const repository = yield* Repository;
+  const parents = new Map<Oid, ReadonlyArray<Oid>>();
+  const pending = [head];
+  while (pending.length > 0) {
+    const commit = pending.pop();
+    if (commit === undefined || parents.has(commit)) continue;
+    if (parents.size >= ceiling) {
+      return yield* new Invalid({
+        field: "lineage",
+        reason: `lineage history exceeds the ${ceiling}-commit ceiling`,
+      });
+    }
+    const record = yield* repository.readCommit(commit);
+    parents.set(commit, record.parents);
+    for (const parent of record.parents) pending.push(parent);
+  }
+  return parents;
+});
+
+/**
+ * Root commit for an origin, or the first commit not reachable from an
+ * upstream for a permanent fork. Concurrent boundary candidates are broken
+ * by oid, so every full clone of the same graph chooses the same key.
+ */
+export const earliestUnique = Effect.fn("social.Lineage.earliestUnique")(function* (input: {
+  readonly head: Oid;
+  readonly upstream?: Oid;
+  readonly ceiling?: number;
+}) {
+  const ceiling = Math.max(1, Math.min(input.ceiling ?? MAX_COMMITS, MAX_COMMITS));
+  const local = yield* history(input.head, ceiling);
+  const upstream =
+    input.upstream === undefined
+      ? new Map<Oid, ReadonlyArray<Oid>>()
+      : yield* history(input.upstream, ceiling);
+  const unique = new Set([...local.keys()].filter((commit) => !upstream.has(commit)));
+  if (unique.size === 0) {
+    return yield* new Invalid({
+      field: "lineage",
+      reason: "the selected revision has no commit unique from its upstream",
+    });
+  }
+
+  const boundary = [...unique]
+    .filter((commit) => !(local.get(commit) ?? []).some((parent) => unique.has(parent)))
+    .sort();
+  const first = boundary[0];
+  if (first === undefined) {
+    return yield* new Invalid({ field: "lineage", reason: "could not find a lineage boundary" });
+  }
+  const lineage = `sha1:${first}`;
+  if (!isLineage(lineage)) {
+    return yield* new Invalid({ field: "lineage", reason: "computed a malformed lineage key" });
+  }
+  return lineage;
+});
+
+export type LineageError = Invalid | ObjectNotFound | StorageFailure;

--- a/src/social/Log.test.ts
+++ b/src/social/Log.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { fingerprint, formatPublicKey, generate } from "../crypto/SshSignature.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import * as Certificate from "../trust/Certificate.ts";
+import { create, signGenesis, writeGenesis } from "../trust/Genesis.ts";
+import * as TrustLog from "../trust/Log.ts";
+import { principalId } from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import * as SocialLog from "./Log.ts";
+import { follow } from "./Statement.ts";
+
+const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        GitRepository.layer.pipe(Layer.provide(GitRepository.hooksNoop), Layer.provide(stores)),
+      ),
+    ),
+  );
+
+describe("social log", () => {
+  it.effect("appends signed statements and verifies them against the identity repository", () =>
+    Effect.promise(async () => {
+      const result = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("alice@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* TrustLog.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(root.publicKey),
+              capabilities: ["social.write"],
+              id: TrustLog.newId(new Date("2026-08-20T00:00:00Z")),
+            }),
+            [root],
+          );
+
+          const trust = yield* projectTrust(genesis);
+          const author = principalId(genesis.repoId);
+          const first = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(new Date("2026-08-20T00:00:01Z")),
+              socialHead: null,
+              trustHead: trust.head,
+              subject: author,
+              petname: "alice",
+              at: new Date("2026-08-20T00:00:01Z"),
+            }),
+            root,
+          );
+          const second = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(new Date("2026-08-20T00:00:02Z")),
+              socialHead: first,
+              trustHead: trust.head,
+              subject: author,
+              petname: "me",
+              at: new Date("2026-08-20T00:00:02Z"),
+            }),
+            root,
+          );
+          const invalid = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(new Date("2026-08-20T00:00:03Z")),
+              socialHead: null,
+              trustHead: trust.head,
+              subject: author,
+              petname: "reset",
+              at: new Date("2026-08-20T00:00:03Z"),
+            }),
+            root,
+          );
+
+          return {
+            first,
+            second,
+            invalid,
+            stored: yield* SocialLog.verified(genesis, trust),
+            head: yield* Repository.pipe(
+              Effect.flatMap((repository) => repository.resolve(SocialLog.LOG_REF)),
+            ),
+          };
+        }),
+      );
+
+      assert.equal(result.head, result.invalid);
+      assert.deepEqual(
+        result.stored.statements.map(({ payload }) => payload.type),
+        ["social.follow", "social.follow"],
+      );
+      assert.equal(result.stored.statements[0]?.commit, result.first);
+      assert.deepEqual(result.stored.rejected, [
+        {
+          commit: result.invalid,
+          reason: "only a first social statement may declare an empty social head",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("does not accept a statement claiming another principal as its author", () =>
+    Effect.promise(async () => {
+      const result = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("alice@example.com");
+          const otherRoot = yield* generate("bob@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          const other = yield* create([formatPublicKey(otherRoot.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* TrustLog.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(root.publicKey),
+              capabilities: ["social.write"],
+              id: TrustLog.newId(),
+            }),
+            [root],
+          );
+          const trust = yield* projectTrust(genesis);
+          yield* SocialLog.issue(
+            follow({
+              author: principalId(other.repoId),
+              id: TrustLog.newId(),
+              socialHead: null,
+              trustHead: trust.head,
+              subject: principalId(other.repoId),
+              petname: "bob",
+            }),
+            root,
+          );
+          return yield* SocialLog.verified(genesis, trust);
+        }),
+      );
+
+      assert.equal(result.statements.length, 0);
+      assert.match(result.rejected[0]?.reason ?? "", /author.*identity repository/i);
+    }),
+  );
+
+  it.effect("holds a descendant statement to the newest trust head its ancestors saw", () =>
+    Effect.promise(async () => {
+      const result = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("root@example.com");
+          const revoked = yield* generate("revoked-device@example.com");
+          const current = yield* generate("current-device@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          for (const device of [revoked, current]) {
+            yield* TrustLog.issue(
+              yield* Certificate.grant({
+                repo: genesis.repoId,
+                publicKey: formatPublicKey(device.publicKey),
+                capabilities: ["social.write"],
+                id: TrustLog.newId(),
+              }),
+              [root],
+            );
+          }
+
+          const beforeRevocation = yield* projectTrust(genesis);
+          const author = principalId(genesis.repoId);
+          const first = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(),
+              socialHead: null,
+              trustHead: beforeRevocation.head,
+              subject: author,
+              petname: "before",
+            }),
+            revoked,
+          );
+
+          yield* TrustLog.issue(
+            Certificate.revoke({
+              repo: genesis.repoId,
+              subject: yield* fingerprint(revoked.publicKey),
+              reason: "rotated",
+              id: TrustLog.newId(),
+            }),
+            [root],
+          );
+          const afterRevocation = yield* projectTrust(genesis);
+          const second = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(),
+              socialHead: first,
+              trustHead: afterRevocation.head,
+              subject: author,
+              petname: "floor",
+            }),
+            current,
+          );
+          const planted = yield* SocialLog.issue(
+            follow({
+              author,
+              id: TrustLog.newId(),
+              socialHead: second,
+              trustHead: beforeRevocation.head,
+              subject: author,
+              petname: "backdated",
+            }),
+            revoked,
+          );
+          return { planted, verified: yield* SocialLog.verified(genesis, afterRevocation) };
+        }),
+      );
+
+      assert.deepEqual(
+        result.verified.statements.flatMap((entry) =>
+          entry.payload.type === "social.follow" ? [entry.payload.petname] : [],
+        ),
+        ["before", "floor"],
+      );
+      assert.equal(
+        result.verified.rejected.some((entry) => entry.commit === result.planted),
+        true,
+      );
+      assert.match(
+        result.verified.rejected.find((entry) => entry.commit === result.planted)?.reason ?? "",
+        /revoked/,
+      );
+    }),
+  );
+});

--- a/src/social/Log.ts
+++ b/src/social/Log.ts
@@ -1,0 +1,423 @@
+/** The append-only social history in one principal's identity repository. */
+import { Context, Effect, Layer, Option } from "effect";
+
+import { NAMESPACE, type Fingerprint, type PrivateKey, sign } from "../crypto/SshSignature.ts";
+import * as Dag from "../git/Dag.ts";
+import { Invalid, type ObjectNotFound, type StorageFailure } from "../git/Error.ts";
+import { Repository } from "../git/Repository.ts";
+import { isOid, type Oid } from "../git/Store.ts";
+import { type Genesis, GENESIS_REF } from "../trust/Genesis.ts";
+import * as TrustLog from "../trust/Log.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+import type { Projection as TrustProjection } from "../trust/Projection.ts";
+import * as Record from "../trust/Record.ts";
+import * as Verify from "../trust/Verify.ts";
+import * as Statement from "./Statement.ts";
+
+export const newId = TrustLog.newId;
+
+export const LOG_REF = "refs/social/log";
+export const RECORD = "statement";
+
+export interface Entry {
+  readonly commit: Oid;
+  readonly parents: ReadonlyArray<Oid>;
+  readonly payload: Statement.SocialStatement;
+  readonly bytes: Uint8Array;
+  readonly signatures: ReadonlyArray<string>;
+}
+
+export interface VerifiedStatement extends Entry {
+  readonly signer: Fingerprint;
+}
+
+export interface Rejected {
+  readonly commit: Oid;
+  readonly reason: string;
+}
+
+/** A verified log is a safe input to the cross-principal projection. */
+export interface VerifiedLog {
+  readonly principal: PrincipalId;
+  readonly head: Oid | null;
+  /** Whole social DAG, joins included, for causal revoke checks. */
+  readonly parents?: ReadonlyMap<Oid, ReadonlyArray<Oid>>;
+  readonly statements: ReadonlyArray<VerifiedStatement>;
+  readonly rejected: ReadonlyArray<Rejected>;
+}
+
+const base = Effect.fn("social.Log.base")(function* () {
+  const repository = yield* Repository;
+  const head = yield* repository.readRef(LOG_REF);
+  if (head !== null) return { parent: head, expected: head };
+
+  const genesis = yield* repository.resolve(GENESIS_REF);
+  if (genesis === null) {
+    return yield* new Invalid({
+      field: "social",
+      reason: "this identity repository has no genesis",
+    });
+  }
+  return { parent: genesis, expected: null };
+});
+
+export const append = Effect.fn("social.Log.append")(
+  function* (
+    payload: Statement.SocialStatement,
+    bytes: Uint8Array,
+    signatures: ReadonlyArray<string>,
+  ) {
+    const repository = yield* Repository;
+    const { expected, parent } = yield* base();
+    const commit = yield* Record.write({
+      name: RECORD,
+      payload: bytes,
+      signatures,
+      parents: [parent],
+      message: `${payload.type} ${payload.id}\n`,
+    });
+    yield* repository.setRef({ name: LOG_REF, to: commit, expected });
+    return commit;
+  },
+  Effect.retry({ times: 3, while: (error) => error._tag === "RefConflict" }),
+);
+
+export const issue = Effect.fn("social.Log.issue")(function* (
+  payload: Statement.SocialStatement,
+  key: PrivateKey | ReadonlyArray<PrivateKey>,
+) {
+  const bytes = Statement.encode(payload);
+  const keys = Array.isArray(key) ? key : [key];
+  const signatures = yield* Effect.forEach(keys, (signer) => sign(signer, bytes, NAMESPACE));
+  return yield* append(payload, bytes, signatures);
+});
+
+export const join = Effect.fn("social.Log.join")(function* (heads: ReadonlyArray<Oid>) {
+  const repository = yield* Repository;
+  if (heads.length < 2) {
+    return yield* new Invalid({ field: "heads", reason: "a join needs two heads or more" });
+  }
+  const tree = yield* repository.writeTree([]);
+  return yield* repository.commitTree({
+    tree,
+    parents: heads,
+    message: "join social logs\n",
+    author: Record.identityAt(new Date()),
+  });
+});
+
+export const isSocialCommit = Effect.fn("social.Log.isSocialCommit")(function* (commit: Oid) {
+  const repository = yield* Repository;
+  const info = yield* repository
+    .readCommit(commit)
+    .pipe(Effect.catchTag("ObjectNotFound", () => Effect.succeed(null)));
+  if (info === null) return false;
+
+  const record = yield* repository
+    .findPath(info.tree, `${RECORD}.json`)
+    .pipe(Effect.catchTag("ObjectNotFound", () => Effect.succeed(null)));
+  if (record !== null) return true;
+  const tree = yield* repository
+    .readTree(info.tree)
+    .pipe(Effect.catchTag("ObjectNotFound", () => Effect.succeed(null)));
+  return tree?.length === 0;
+});
+
+export const MAX_RECORDS = 16_384;
+
+export class Ceiling extends Context.Service<Ceiling, number>()("social/Log/Ceiling") {}
+
+export const ceiling = (records: number): Layer.Layer<Ceiling> => Layer.succeed(Ceiling)(records);
+
+export const ceilingOf = Effect.fnUntraced(function* () {
+  return Option.getOrElse(yield* Effect.serviceOption(Ceiling), () => MAX_RECORDS);
+});
+
+export const withinCeiling = Effect.fn("social.Log.withinCeiling")(function* (head: Oid) {
+  const repository = yield* Repository;
+  const genesis = yield* repository.resolve(GENESIS_REF);
+  return yield* Dag.reachable(
+    head,
+    genesis,
+    (commit) => isSocialCommit(commit),
+    yield* ceilingOf(),
+  ).pipe(
+    Effect.as(true),
+    Effect.catchTag("Invalid", () => Effect.succeed(false)),
+  );
+});
+
+/** Raw, structurally decodable records in deterministic topological order. */
+export const entries = Effect.fn("social.Log.entries")(function* () {
+  const repository = yield* Repository;
+  const head = yield* repository.resolve(LOG_REF);
+  if (head === null) return { records: [], parents: new Map<Oid, ReadonlyArray<Oid>>() };
+
+  const genesis = yield* repository.resolve(GENESIS_REF);
+  const parents = yield* Dag.reachable(head, genesis, (commit) => isSocialCommit(commit));
+  const records: Entry[] = [];
+  for (const commit of Dag.topological(parents)) {
+    if (!(yield* Record.carries(commit, RECORD))) continue;
+    const record = yield* Record.read(commit, RECORD).pipe(
+      Effect.catchTags({
+        Invalid: () => Effect.succeed(null),
+        ObjectNotFound: () => Effect.succeed(null),
+      }),
+    );
+    if (record === null) continue;
+    const payload = yield* Statement.decode(record.payload).pipe(Effect.orElseSucceed(() => null));
+    if (payload === null) continue;
+    records.push({
+      commit,
+      parents: parents.get(commit) ?? [],
+      payload,
+      bytes: record.payload,
+      signatures: record.signatures,
+    });
+  }
+  return { records, parents };
+});
+
+const ancestorsOf = (commit: Oid, parents: Dag.Parents): ReadonlySet<Oid> => {
+  const seen = new Set<Oid>();
+  const pending = [...(parents.get(commit) ?? [])];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) break;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    pending.push(...(parents.get(current) ?? []));
+  }
+  return seen;
+};
+
+/** How strongly one candidate is embedded in the rest of the log. */
+const rankOf = (commit: Oid, parents: Dag.Parents): readonly [number, number, Oid] => {
+  let descendants = 0;
+  for (const candidate of parents.keys()) {
+    if (ancestorsOf(candidate, parents).has(commit)) descendants++;
+  }
+  return [descendants, ancestorsOf(commit, parents).size, commit];
+};
+
+const winners = (
+  records: ReadonlyArray<VerifiedStatement>,
+  parents: Dag.Parents,
+): ReadonlySet<Oid> => {
+  const byId = new Map<string, VerifiedStatement[]>();
+  for (const record of records) {
+    byId.set(record.payload.id, [...(byId.get(record.payload.id) ?? []), record]);
+  }
+
+  const selected = new Set<Oid>();
+  for (const candidates of byId.values()) {
+    const first = candidates[0];
+    if (first === undefined) continue;
+    let best = first;
+    let rank = rankOf(best.commit, parents);
+    for (const candidate of candidates.slice(1)) {
+      const next = rankOf(candidate.commit, parents);
+      const better =
+        next[0] !== rank[0]
+          ? next[0] > rank[0]
+          : next[1] !== rank[1]
+            ? next[1] > rank[1]
+            : next[2] < rank[2];
+      if (better) {
+        best = candidate;
+        rank = next;
+      }
+    }
+    selected.add(best.commit);
+  }
+  return selected;
+};
+
+/**
+ * Verify authorship and `social.write` against this identity's trust log.
+ * Invalid records stay observable in `rejected` and contribute no graph edge.
+ */
+export const verified = Effect.fn("social.Log.verified")(function* (
+  genesis: Genesis,
+  trust: TrustProjection,
+) {
+  const repository = yield* Repository;
+  const { parents, records } = yield* entries();
+  const accepted: VerifiedStatement[] = [];
+  const rejected: Rejected[] = [];
+  const identity = principalId(genesis.repoId);
+  const recordCommits = new Set(records.map((record) => record.commit));
+  const hasEarlierRecord = new Map<Oid, boolean>();
+  for (const commit of Dag.topological(parents)) {
+    hasEarlierRecord.set(
+      commit,
+      (parents.get(commit) ?? []).some(
+        (parent) => recordCommits.has(parent) || hasEarlierRecord.get(parent) === true,
+      ),
+    );
+  }
+
+  /** Trust ancestry is immutable for this fold, so each declared head is walked once. */
+  const trustAncestry = new Map<Oid, ReadonlySet<Oid> | null>();
+  const seenTrust: Verify.Ancestry = Effect.fnUntraced(function* (head: Oid) {
+    if (trustAncestry.has(head)) {
+      const known = trustAncestry.get(head);
+      if (known === null || known === undefined) {
+        return yield* new Invalid({ field: "trustHead", reason: `${head} cannot be walked` });
+      }
+      return known;
+    }
+    const walked = yield* TrustLog.ancestry(head).pipe(Effect.catch(() => Effect.succeed(null)));
+    trustAncestry.set(head, walked);
+    if (walked === null) {
+      return yield* new Invalid({ field: "trustHead", reason: `${head} cannot be walked` });
+    }
+    return walked;
+  });
+  const trustMembership = new Map<Oid, boolean>();
+  const containsTrust: Verify.Membership = Effect.fnUntraced(function* (commit: Oid) {
+    const known = trustMembership.get(commit);
+    if (known !== undefined) return known;
+    const contained = yield* TrustLog.contains(commit).pipe(
+      Effect.catch(() => Effect.succeed(false)),
+    );
+    trustMembership.set(commit, contained);
+    return contained;
+  });
+  const reachesTrust = Effect.fnUntraced(function* (head: Oid | null, target: Oid) {
+    if (head === null || head === target) return true;
+    return yield* seenTrust(head).pipe(
+      Effect.map((seen) => seen.has(target)),
+      Effect.catch(() => Effect.succeed(false)),
+    );
+  });
+
+  /** Newest accepted trust head carried through social statements and joins. */
+  const trustFloorAt = new Map<Oid, Oid | null>();
+  const floorThrough: (
+    commit: Oid,
+  ) => Effect.Effect<Oid | null, Invalid | ObjectNotFound | StorageFailure, Repository> =
+    Effect.fnUntraced(function* (commit: Oid) {
+      if (trustFloorAt.has(commit)) return trustFloorAt.get(commit) ?? null;
+      let floor: Oid | null = null;
+      for (const parent of parents.get(commit) ?? []) {
+        const candidate = yield* floorThrough(parent);
+        if (candidate === null || candidate === floor) continue;
+        if (floor === null || (yield* reachesTrust(candidate, floor))) floor = candidate;
+      }
+      trustFloorAt.set(commit, floor);
+      return floor;
+    });
+
+  for (const entry of records) {
+    let floor: Oid | null = null;
+    for (const parent of entry.parents) {
+      const candidate = yield* floorThrough(parent);
+      if (candidate === null || candidate === floor) continue;
+      if (floor === null || (yield* reachesTrust(candidate, floor))) floor = candidate;
+    }
+    // Rejected statements carry their accepted ancestors' floor forward.
+    trustFloorAt.set(entry.commit, floor);
+
+    const invalid = yield* Statement.validate(entry.payload, identity).pipe(
+      Effect.as(null),
+      Effect.catchTag("Invalid", (error) => Effect.succeed(error.reason)),
+    );
+    if (invalid !== null) {
+      rejected.push({ commit: entry.commit, reason: invalid });
+      continue;
+    }
+
+    const declared = entry.payload.socialHead;
+    if (declared !== null && !isOid(declared)) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `declared social head ${declared} is invalid`,
+      });
+      continue;
+    }
+    if (declared !== null && !ancestorsOf(entry.commit, parents).has(declared)) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `declared social head ${declared} is not an ancestor of this statement`,
+      });
+      continue;
+    }
+    if (declared === null && hasEarlierRecord.get(entry.commit) === true) {
+      rejected.push({
+        commit: entry.commit,
+        reason: "only a first social statement may declare an empty social head",
+      });
+      continue;
+    }
+
+    const trustHead = entry.payload.trustHead;
+    if (trustHead !== null && !isOid(trustHead)) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `declared trust head ${trustHead} is invalid`,
+      });
+      continue;
+    }
+    if (trustHead !== null && !(yield* containsTrust(trustHead))) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `declared trust head ${trustHead} is not in this identity's trust log`,
+      });
+      continue;
+    }
+    const behind = floor !== null && !(yield* reachesTrust(trustHead, floor));
+    const effectiveTrustHead = behind ? floor : trustHead;
+    const authorization = yield* Verify.authorize({
+      projection: trust,
+      bytes: entry.bytes,
+      signatures: entry.signatures,
+      capability: "social.write",
+      made: { at: new Date(entry.payload.issuedAt), trustHead: effectiveTrustHead },
+      seen: seenTrust,
+      contains: containsTrust,
+    });
+    if (!authorization.ok) {
+      rejected.push({ commit: entry.commit, reason: authorization.reason });
+      continue;
+    }
+    accepted.push({ ...entry, signer: authorization.principal.fingerprint });
+    if (effectiveTrustHead !== null) trustFloorAt.set(entry.commit, effectiveTrustHead);
+  }
+
+  const selected = winners(accepted, parents);
+  for (const entry of accepted) {
+    if (!selected.has(entry.commit)) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `${entry.payload.id} has already been applied`,
+      });
+    }
+  }
+
+  return {
+    principal: identity,
+    head: yield* repository.resolve(LOG_REF),
+    parents,
+    statements: accepted.filter((entry) => selected.has(entry.commit)),
+    rejected,
+  } satisfies VerifiedLog;
+});
+
+export const contains = Effect.fn("social.Log.contains")(function* (commit: Oid) {
+  const repository = yield* Repository;
+  const head = yield* repository.resolve(LOG_REF);
+  if (head === null) return false;
+  const genesis = yield* repository.resolve(GENESIS_REF);
+  return (yield* Dag.reachable(head, genesis, (oid) => isSocialCommit(oid))).has(commit);
+});
+
+export const ancestry = Effect.fn("social.Log.ancestry")(function* (from: Oid) {
+  const repository = yield* Repository;
+  const genesis = yield* repository.resolve(GENESIS_REF);
+  return new Set(
+    (yield* Dag.reachable(from, genesis, (oid) => isSocialCommit(oid), yield* ceilingOf())).keys(),
+  );
+});
+
+export type LogError = Invalid | ObjectNotFound | StorageFailure;

--- a/src/social/Projection.test.ts
+++ b/src/social/Projection.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect } from "effect";
+
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import type { Oid } from "../git/Store.ts";
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+import type { VerifiedLog, VerifiedStatement } from "./Log.ts";
+import { confidence, fresh, pathsTo, project } from "./Projection.ts";
+import {
+  checkpoint,
+  encode,
+  follow,
+  mirrors,
+  revoke,
+  vouch,
+  type SocialStatement,
+} from "./Statement.ts";
+
+/** SAFETY: forty-three base64 characters after `SHA256:`, which is the shape. */
+const repoId = (seed: string): RepoId => `SHA256:${seed.repeat(43).slice(0, 43)}` as RepoId;
+const principal = (seed: string): PrincipalId => principalId(repoId(seed));
+
+const alice = principal("a");
+const bob = principal("b");
+const carol = principal("c");
+const dave = principal("d");
+const eve = principal("e");
+const now = new Date("2026-08-20T12:00:00Z");
+
+const oid = (value: number): Oid => {
+  // SAFETY: exactly forty lowercase hexadecimal characters.
+  return value.toString(16).padStart(40, "0") as Oid;
+};
+
+const signer = (seed: string): Fingerprint => {
+  // SAFETY: the same fingerprint spelling validated by the crypto module.
+  return `SHA256:${seed.repeat(43).slice(0, 43)}` as Fingerprint;
+};
+
+const record = (payload: SocialStatement, index: number): VerifiedStatement => ({
+  commit: oid(index),
+  parents: index === 1 ? [] : [oid(index - 1)],
+  payload,
+  bytes: encode(payload),
+  signatures: [],
+  signer: signer(payload.author.slice("SHA256:".length, "SHA256:".length + 1)),
+});
+
+const log = (owner: PrincipalId, statements: ReadonlyArray<SocialStatement>): VerifiedLog => ({
+  principal: owner,
+  head: statements.length === 0 ? null : oid(statements.length),
+  statements: statements.map(record),
+  rejected: [],
+});
+
+const context = (author: PrincipalId, index: number) => ({
+  author,
+  id: `018bcfe5-6800-7000-8000-${index.toString().padStart(12, "0")}`,
+  socialHead: index === 1 ? null : oid(index - 1),
+  trustHead: null,
+  at: new Date(now.getTime() + index),
+});
+
+describe("social projection", () => {
+  it.effect("attenuates scope and stops when an intermediate vouch cannot extend", () =>
+    Effect.sync(() => {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            vouch({
+              ...context(alice, 1),
+              subject: bob,
+              scope: ["introduce.repo", "vouch"],
+              depth: 1,
+            }),
+          ]),
+          log(bob, [
+            vouch({
+              ...context(bob, 1),
+              subject: carol,
+              scope: ["introduce.repo"],
+              depth: 1,
+            }),
+          ]),
+          log(carol, [
+            vouch({
+              ...context(carol, 1),
+              subject: dave,
+              scope: ["introduce.repo"],
+              depth: 0,
+            }),
+          ]),
+        ],
+        at: now,
+      });
+
+      assert.equal(pathsTo(projection, bob, "introduce.repo").length, 1);
+      assert.equal(pathsTo(projection, bob, "review").length, 0, "scope only narrows");
+      assert.equal(pathsTo(projection, carol, "introduce.repo").length, 1);
+      assert.equal(
+        pathsTo(projection, dave, "introduce.repo").length,
+        0,
+        "a path without vouch scope cannot be extended",
+      );
+    }),
+  );
+
+  it.effect("counts independent paths rather than vouch statements", () =>
+    Effect.sync(() => {
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            vouch({
+              ...context(alice, 1),
+              subject: bob,
+              scope: ["review", "vouch"],
+              depth: 1,
+            }),
+            vouch({
+              ...context(alice, 2),
+              subject: carol,
+              scope: ["review", "vouch"],
+              depth: 1,
+            }),
+          ]),
+          log(bob, [
+            vouch({
+              ...context(bob, 1),
+              subject: dave,
+              scope: ["review"],
+              depth: 0,
+            }),
+          ]),
+          log(carol, [
+            vouch({
+              ...context(carol, 1),
+              subject: dave,
+              scope: ["review"],
+              depth: 0,
+            }),
+          ]),
+        ],
+        at: now,
+      });
+
+      assert.equal(pathsTo(projection, dave, "review").length, 2);
+      assert.equal(confidence(projection, dave, "review"), 2);
+    }),
+  );
+
+  it.effect("never reads follows as trust edges", () =>
+    Effect.sync(() => {
+      const projection = project({
+        roots: [alice],
+        logs: [log(alice, [follow({ ...context(alice, 1), subject: eve, petname: "eve" })])],
+        at: now,
+      });
+
+      assert.equal(pathsTo(projection, eve, "introduce.repo").length, 0);
+      assert.equal(projection.petnames.get(alice)?.get(eve), "eve");
+    }),
+  );
+
+  it.effect("withdraws a vouch and restores it when the withdrawal is itself revoked", () =>
+    Effect.sync(() => {
+      const vouched = vouch({
+        ...context(alice, 1),
+        subject: bob,
+        scope: ["review"],
+        depth: 0,
+      });
+      const withdrawn = revoke({
+        ...context(alice, 2),
+        target: vouched.id,
+        reason: "withdrawn",
+      });
+
+      const without = project({
+        roots: [alice],
+        logs: [log(alice, [vouched, withdrawn])],
+        at: now,
+      });
+      assert.equal(confidence(without, bob, "review"), 0);
+
+      const restored = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            vouched,
+            withdrawn,
+            revoke({ ...context(alice, 3), target: withdrawn.id, reason: "superseded" }),
+          ]),
+        ],
+        at: now,
+      });
+      assert.equal(confidence(restored, bob, "review"), 1);
+    }),
+  );
+
+  it.effect("projects only the newest active mirror list for a repository", () =>
+    Effect.sync(() => {
+      const graph = project({
+        roots: [alice],
+        logs: [
+          log(alice, [
+            mirrors({
+              ...context(alice, 1),
+              repo: "self",
+              urls: [{ url: "https://old.example/alice", mode: "read" }],
+            }),
+            mirrors({
+              ...context(alice, 2),
+              repo: "self",
+              urls: [{ url: "https://new.example/alice", mode: "write" }],
+            }),
+          ]),
+        ],
+        at: now,
+      });
+      const locations = graph.active.filter(
+        (statement) => statement.payload.type === "social.mirrors",
+      );
+      assert.equal(locations.length, 1);
+      assert.equal(locations[0]?.payload.type, "social.mirrors");
+      if (locations[0]?.payload.type === "social.mirrors") {
+        assert.equal(locations[0].payload.urls[0]?.url, "https://new.example/alice");
+      }
+    }),
+  );
+
+  it.effect("bounds a reachable vouch path by its author's social checkpoint", () =>
+    Effect.sync(() => {
+      const vouched = vouch({
+        ...context(alice, 1),
+        subject: bob,
+        scope: ["review"],
+        depth: 0,
+      });
+      const without = project({ roots: [alice], logs: [log(alice, [vouched])], at: now });
+      assert.equal(fresh(without, 60_000, now).ok, false);
+
+      const recent = checkpoint({
+        ...context(alice, 2),
+        frontier: [oid(1)],
+        at: new Date(now.getTime() - 30_000),
+      });
+      const bounded = project({
+        roots: [alice],
+        logs: [log(alice, [vouched, recent])],
+        at: now,
+      });
+      assert.equal(fresh(bounded, 60_000, now).ok, true);
+      assert.equal(fresh(bounded, 10_000, now).ok, false);
+    }),
+  );
+});

--- a/src/social/Projection.ts
+++ b/src/social/Projection.ts
@@ -1,0 +1,412 @@
+/** A verifier-rooted, deterministic projection over locally held social logs. */
+import { Context, Effect, Layer } from "effect";
+
+import type { Oid } from "../git/Store.ts";
+import { isPrincipalId, principalOf, type PrincipalId } from "../trust/Principal.ts";
+import type { VerifiedLog, VerifiedStatement } from "./Log.ts";
+import { SOCIAL_SCOPES, type SocialScope } from "./Statement.ts";
+
+const MAX_DEPTH = 16;
+const MAX_PATHS = 4096;
+const MAX_CHECKPOINTS = 32;
+const CLOCK_SKEW_MS = 300_000;
+const scopes = new Set<string>(SOCIAL_SCOPES);
+
+const isSocialScope = (scope: string): scope is SocialScope => scopes.has(scope);
+
+export interface TrustPath {
+  /** Root first, reached subject last. */
+  readonly principals: ReadonlyArray<PrincipalId>;
+  /** The vouch statements whose edges make this path. */
+  readonly statements: ReadonlyArray<Oid>;
+  /** Intersection of every edge's scope. */
+  readonly scopes: ReadonlySet<SocialScope>;
+  /** How many further vouch edges the narrowest edge still allows. */
+  readonly remainingDepth: number;
+}
+
+export interface ProjectionRejected {
+  readonly commit: Oid;
+  readonly reason: string;
+}
+
+export interface SocialCheckpoint {
+  readonly principal: PrincipalId;
+  readonly commit: Oid;
+  readonly at: Date;
+  readonly frontier: ReadonlyArray<string>;
+}
+
+export interface Projection {
+  readonly roots: ReadonlyArray<PrincipalId>;
+  readonly logs: ReadonlyArray<VerifiedLog>;
+  readonly active: ReadonlyArray<VerifiedStatement>;
+  readonly paths: ReadonlyMap<PrincipalId, ReadonlyArray<TrustPath>>;
+  readonly petnames: ReadonlyMap<PrincipalId, ReadonlyMap<PrincipalId, string>>;
+  /** Bounded newest-first checkpoint evidence, grouped by the log that made it. */
+  readonly checkpoints: ReadonlyMap<PrincipalId, ReadonlyArray<SocialCheckpoint>>;
+  readonly rejected: ReadonlyArray<ProjectionRejected>;
+  readonly at: Date;
+  readonly truncated: boolean;
+}
+
+/** Verified social logs already synchronized for one policy decision. */
+export class SocialWeb extends Context.Service<
+  SocialWeb,
+  { readonly logs: Effect.Effect<ReadonlyArray<VerifiedLog>> }
+>()("social/Projection/SocialWeb") {}
+
+export const socialWebInMemory = (logs: ReadonlyArray<VerifiedLog>): Layer.Layer<SocialWeb> =>
+  Layer.succeed(SocialWeb)({ logs: Effect.succeed(logs) });
+
+/**
+ * Current statements in one log.
+ *
+ * Revoke edges point backwards. Walking newest-to-oldest therefore settles a
+ * revoke before its target and naturally handles revoking a revoke: an
+ * inactive revoke never withdraws its own target.
+ */
+interface ActiveStatements {
+  readonly active: ReadonlyArray<VerifiedStatement>;
+  readonly rejected: ReadonlyArray<ProjectionRejected>;
+}
+
+const activeOf = (log: VerifiedLog): ActiveStatements => {
+  const positions = new Map<string, number>();
+  const statements = new Map<string, VerifiedStatement>();
+  for (const [index, statement] of log.statements.entries()) {
+    if (!positions.has(statement.payload.id)) {
+      positions.set(statement.payload.id, index);
+      statements.set(statement.payload.id, statement);
+    }
+  }
+
+  const reaches = (from: Oid, target: Oid): boolean => {
+    if (from === target) return true;
+    if (log.parents === undefined) return true;
+    const seen = new Set<Oid>();
+    const pending = [...(log.parents.get(from) ?? [])];
+    while (pending.length > 0) {
+      const commit = pending.pop();
+      if (commit === undefined || seen.has(commit)) continue;
+      if (commit === target) return true;
+      seen.add(commit);
+      pending.push(...(log.parents.get(commit) ?? []));
+    }
+    return false;
+  };
+
+  const withdrawn = new Set<string>();
+  const superseded = new Set<string>();
+  const active: VerifiedStatement[] = [];
+  const rejected: ProjectionRejected[] = [];
+  for (let index = log.statements.length - 1; index >= 0; index--) {
+    const statement = log.statements[index];
+    if (statement === undefined) continue;
+    if (withdrawn.has(statement.payload.id)) continue;
+
+    // These are replaceable *views* expressed by append-only records. A
+    // revoked newest value reveals the value before it; otherwise only the
+    // newest value for the same subject participates in the current fold.
+    const replacementKey =
+      statement.payload.type === "social.mirrors"
+        ? `mirrors\u0000${statement.payload.repo}`
+        : statement.payload.type === "social.follow"
+          ? `follow\u0000${statement.payload.subject}`
+          : null;
+    if (replacementKey !== null) {
+      if (superseded.has(replacementKey)) continue;
+      superseded.add(replacementKey);
+    }
+    active.push(statement);
+
+    if (statement.payload.type !== "social.revoke") continue;
+    const target = positions.get(statement.payload.target);
+    const targetStatement = statements.get(statement.payload.target);
+    if (
+      target === undefined ||
+      target >= index ||
+      targetStatement === undefined ||
+      !reaches(statement.commit, targetStatement.commit)
+    ) {
+      active.pop();
+      rejected.push({
+        commit: statement.commit,
+        reason: `revoke target ${statement.payload.target} is not an earlier statement in this log`,
+      });
+      continue;
+    }
+    withdrawn.add(statement.payload.target);
+  }
+  active.reverse();
+  return { active, rejected };
+};
+
+interface VouchEdge {
+  readonly from: PrincipalId;
+  readonly to: PrincipalId;
+  readonly scope: ReadonlySet<SocialScope>;
+  readonly depth: number;
+  readonly commit: Oid;
+}
+
+const intersect = (
+  left: ReadonlySet<SocialScope>,
+  right: ReadonlySet<SocialScope>,
+): ReadonlySet<SocialScope> => {
+  const found = new Set<SocialScope>();
+  for (const scope of left) if (right.has(scope)) found.add(scope);
+  return found;
+};
+
+const pathKey = (path: TrustPath): string =>
+  `${path.principals.join("\u0000")}\u0001${[...path.scopes].sort().join(",")}`;
+
+export const project = (input: {
+  readonly roots: ReadonlyArray<PrincipalId>;
+  readonly logs: ReadonlyArray<VerifiedLog>;
+  readonly at?: Date;
+  readonly maxDepth?: number;
+}): Projection => {
+  const at = input.at ?? new Date();
+  const rejected: ProjectionRejected[] = [];
+  const active: VerifiedStatement[] = [];
+  for (const log of input.logs) {
+    const current = activeOf(log);
+    active.push(...current.active);
+    rejected.push(...current.rejected);
+  }
+
+  const edges = new Map<PrincipalId, VouchEdge[]>();
+  const petnames = new Map<PrincipalId, Map<PrincipalId, string>>();
+  const checkpointCandidates = new Map<PrincipalId, SocialCheckpoint[]>();
+  for (const statement of active) {
+    if (!isPrincipalId(statement.payload.author)) continue;
+    if (statement.payload.type === "social.checkpoint") {
+      const held = checkpointCandidates.get(statement.payload.author) ?? [];
+      held.push({
+        principal: statement.payload.author,
+        commit: statement.commit,
+        at: new Date(statement.payload.issuedAt),
+        frontier: statement.payload.frontier,
+      });
+      checkpointCandidates.set(statement.payload.author, held);
+      continue;
+    }
+    if (statement.payload.type === "social.follow") {
+      const subject = principalOf(statement.payload.subject);
+      if (subject === null) continue;
+      const names = petnames.get(statement.payload.author) ?? new Map<PrincipalId, string>();
+      names.set(subject, statement.payload.petname);
+      petnames.set(statement.payload.author, names);
+      continue;
+    }
+    if (statement.payload.type !== "social.vouch") continue;
+    if (
+      statement.payload.expiresAt !== null &&
+      Date.parse(statement.payload.expiresAt) <= at.getTime()
+    ) {
+      continue;
+    }
+    const subject = principalOf(statement.payload.subject);
+    if (subject === null) continue;
+    const edge: VouchEdge = {
+      from: statement.payload.author,
+      to: subject,
+      scope: new Set(statement.payload.scope.filter(isSocialScope)),
+      depth: statement.payload.depth,
+      commit: statement.commit,
+    };
+    edges.set(edge.from, [...(edges.get(edge.from) ?? []), edge]);
+  }
+  for (const outgoing of edges.values()) {
+    outgoing.sort((left, right) =>
+      left.to !== right.to ? (left.to < right.to ? -1 : 1) : left.commit < right.commit ? -1 : 1,
+    );
+  }
+  const checkpoints = new Map<PrincipalId, ReadonlyArray<SocialCheckpoint>>();
+  for (const [principal, candidates] of checkpointCandidates) {
+    checkpoints.set(
+      principal,
+      candidates
+        .sort((left, right) =>
+          left.at.getTime() !== right.at.getTime()
+            ? right.at.getTime() - left.at.getTime()
+            : left.commit < right.commit
+              ? -1
+              : 1,
+        )
+        .slice(0, MAX_CHECKPOINTS),
+    );
+  }
+
+  const found = new Map<PrincipalId, TrustPath[]>();
+  const pending: TrustPath[] = [];
+  const allScopes = new Set<SocialScope>(SOCIAL_SCOPES);
+  for (const root of [...new Set(input.roots)].sort()) {
+    const path: TrustPath = {
+      principals: [root],
+      statements: [],
+      scopes: allScopes,
+      remainingDepth: Number.POSITIVE_INFINITY,
+    };
+    found.set(root, [...(found.get(root) ?? []), path]);
+    pending.push(path);
+  }
+
+  const seen = new Set(pending.map(pathKey));
+  const maxDepth = Math.max(0, Math.min(input.maxDepth ?? MAX_DEPTH, MAX_DEPTH));
+  let total = pending.length;
+  let truncated = false;
+  while (pending.length > 0) {
+    const path = pending.shift();
+    if (path === undefined) break;
+    const hops = path.principals.length - 1;
+    if (hops >= maxDepth) continue;
+    // A root is an explicit anchor. Every later principal may extend the web
+    // only when the path that reached it retained `vouch` scope and depth.
+    if (hops > 0 && (!path.scopes.has("vouch") || path.remainingDepth <= 0)) continue;
+
+    const current = path.principals.at(-1);
+    if (current === undefined) continue;
+    for (const edge of edges.get(current) ?? []) {
+      if (path.principals.includes(edge.to)) continue;
+      const effective = intersect(path.scopes, edge.scope);
+      if (effective.size === 0) continue;
+
+      const remaining =
+        hops === 0 ? edge.depth : Math.min(Math.max(0, path.remainingDepth - 1), edge.depth);
+      const next: TrustPath = {
+        principals: [...path.principals, edge.to],
+        statements: [...path.statements, edge.commit],
+        scopes: effective,
+        remainingDepth: remaining,
+      };
+      const key = pathKey(next);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      found.set(edge.to, [...(found.get(edge.to) ?? []), next]);
+      pending.push(next);
+      total++;
+      if (total >= MAX_PATHS) {
+        truncated = true;
+        pending.length = 0;
+        break;
+      }
+    }
+  }
+
+  return {
+    roots: [...new Set(input.roots)],
+    logs: input.logs,
+    active,
+    paths: found,
+    petnames,
+    checkpoints,
+    rejected,
+    at,
+    truncated,
+  };
+};
+
+export type Freshness = { readonly ok: true } | { readonly ok: false; readonly reason: string };
+
+/**
+ * Bound stale social views without letting unrelated locally held logs veto a
+ * decision. Only principals whose vouches occur on a reachable path need a
+ * checkpoint; explicit roots need no graph statement to be trusted.
+ */
+export const fresh = (
+  projection: Projection,
+  maxAgeMs: number,
+  now: Date = new Date(),
+): Freshness => {
+  const relevant = new Set<PrincipalId>();
+  for (const paths of projection.paths.values()) {
+    for (const path of paths) {
+      for (const principal of path.principals.slice(0, -1)) relevant.add(principal);
+    }
+  }
+
+  for (const principal of [...relevant].sort()) {
+    const checkpoints = projection.checkpoints.get(principal) ?? [];
+    let future = 0;
+    let credible: SocialCheckpoint | null = null;
+    for (const checkpoint of checkpoints) {
+      if (checkpoint.at.getTime() - now.getTime() > CLOCK_SKEW_MS) {
+        future++;
+        continue;
+      }
+      credible = checkpoint;
+      break;
+    }
+    if (credible === null) {
+      return {
+        ok: false,
+        reason:
+          future === 0
+            ? `${principal}'s social log has no checkpoint`
+            : `${principal}'s social checkpoints are dated in the future`,
+      };
+    }
+    const age = now.getTime() - credible.at.getTime();
+    if (age > maxAgeMs) {
+      return {
+        ok: false,
+        reason: `${principal}'s social checkpoint is ${Math.floor(age / 1000)}s old`,
+      };
+    }
+  }
+  return { ok: true };
+};
+
+/** Every distinct principal route retaining one scope, before independence. */
+export const pathsTo = (
+  projection: Projection,
+  subject: PrincipalId,
+  scope: SocialScope,
+  maxDepth = MAX_DEPTH,
+): ReadonlyArray<TrustPath> => {
+  const distinct = new Map<string, TrustPath>();
+  for (const path of projection.paths.get(subject) ?? []) {
+    if (!path.scopes.has(scope) || path.principals.length - 1 > maxDepth) continue;
+    // Different statements over the same principal route are corroboration by
+    // nobody new, so they are one path for confidence purposes.
+    const key = path.principals.join("\u0000");
+    const held = distinct.get(key);
+    if (held === undefined || path.statements.join("") < held.statements.join("")) {
+      distinct.set(key, path);
+    }
+  }
+  return [...distinct.values()].sort((left, right) =>
+    left.principals.length !== right.principals.length
+      ? left.principals.length - right.principals.length
+      : left.principals.join("") < right.principals.join("")
+        ? -1
+        : 1,
+  );
+};
+
+/**
+ * A conservative maximal set of paths sharing no intermediate principal.
+ * Shortest deterministic routes are selected first; under-counting refuses a
+ * decision, while over-counting would create trust that is not there.
+ */
+export const independentPaths = (paths: ReadonlyArray<TrustPath>): ReadonlyArray<TrustPath> => {
+  const selected: TrustPath[] = [];
+  const intermediates = new Set<PrincipalId>();
+  for (const path of paths) {
+    const inside = path.principals.slice(1, -1);
+    if (inside.some((principal) => intermediates.has(principal))) continue;
+    selected.push(path);
+    for (const principal of inside) intermediates.add(principal);
+  }
+  return selected;
+};
+
+export const confidence = (
+  projection: Projection,
+  subject: PrincipalId,
+  scope: SocialScope,
+  maxDepth = MAX_DEPTH,
+): number => independentPaths(pathsTo(projection, subject, scope, maxDepth)).length;

--- a/src/social/Review.test.ts
+++ b/src/social/Review.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { formatPublicKey, generate } from "../crypto/SshSignature.ts";
+import { EMPTY_TREE_OID } from "../git/Format.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import * as PullRequest from "../hub/PullRequest.ts";
+import { project as projectPullRequest } from "../hub/Projection.ts";
+import * as Certificate from "../trust/Certificate.ts";
+import { create, signGenesis, writeGenesis } from "../trust/Genesis.ts";
+import * as Log from "../trust/Log.ts";
+import { identitiesInMemory, principalId, type ResolvedIdentity } from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import { externalReviews } from "./Review.ts";
+
+const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        GitRepository.layer.pipe(
+          Layer.provide(GitRepository.hooksNoop),
+          Layer.provideMerge(stores),
+        ),
+      ),
+    ),
+  );
+
+describe("external reviews", () => {
+  it.effect("accepts a review only after its signer resolves through the named identity", () =>
+    Effect.promise(async () => {
+      const identity = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("identity-root@example.com");
+          const reviewer = yield* generate("reviewer@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(reviewer.publicKey),
+              capabilities: [],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const projection = yield* projectTrust(genesis);
+          return {
+            key: reviewer,
+            resolved: {
+              principal: principalId(genesis.repoId),
+              projection,
+              head: projection.head,
+            } satisfies ResolvedIdentity,
+          };
+        }),
+      );
+
+      const outcome = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("project-root@example.com");
+          const author = yield* generate("author@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(author.publicKey),
+              capabilities: ["hub.create-pr"],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+
+          const opened = yield* PullRequest.open({
+            repo: genesis.repoId,
+            title: "external review",
+            base: "refs/heads/main",
+            head: EMPTY_TREE_OID,
+            key: author,
+          });
+          if (identity.resolved.head === null) {
+            assert.fail("the identity fixture must have a trust-log head");
+          }
+          yield* PullRequest.review({
+            repo: genesis.repoId,
+            pr: opened.pr,
+            head: EMPTY_TREE_OID,
+            base: "refs/heads/main",
+            principal: identity.resolved.principal,
+            identityHead: identity.resolved.head,
+            decision: "approve",
+            key: identity.key,
+          });
+
+          const trust = yield* projectTrust(genesis);
+          const pullRequest = yield* projectPullRequest(genesis, trust, opened.pr);
+          const absent = yield* externalReviews(genesis, pullRequest, opened.pr);
+          const resolved = yield* externalReviews(genesis, pullRequest, opened.pr).pipe(
+            Effect.provide(identitiesInMemory([identity.resolved])),
+          );
+          const movedIdentity: ResolvedIdentity = {
+            ...identity.resolved,
+            head: EMPTY_TREE_OID,
+            projection: { ...identity.resolved.projection, head: EMPTY_TREE_OID },
+          };
+          const moved = yield* externalReviews(genesis, pullRequest, opened.pr).pipe(
+            Effect.provide(identitiesInMemory([movedIdentity])),
+          );
+          return { absent, moved, resolved, pullRequest };
+        }),
+      );
+
+      assert.equal(outcome.pullRequest.reviews.length, 0, "it is not local repository authority");
+      assert.equal(outcome.absent.reviews.length, 0, "an unavailable identity stays quarantined");
+      assert.equal(outcome.resolved.reviews.length, 1);
+      assert.equal(outcome.resolved.reviews[0]?.principal, identity.resolved.principal);
+      assert.equal(outcome.moved.reviews.length, 0);
+      assert.match(
+        outcome.moved.rejected[0]?.reason ?? "",
+        /pinned identity head/,
+        "an external signature is bound to the identity view it names",
+      );
+    }),
+  );
+});

--- a/src/social/Review.ts
+++ b/src/social/Review.ts
@@ -1,0 +1,171 @@
+/** Identity-verified reviews whose authors are outside project membership. */
+import { Effect } from "effect";
+
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import type { Oid } from "../git/Store.ts";
+import * as Event from "../hub/Event.ts";
+import type { PullRequest, Review } from "../hub/Projection.ts";
+import type { Genesis } from "../trust/Genesis.ts";
+import {
+  containsIdentityKey,
+  identifyKey,
+  isPrincipalId,
+  type PrincipalId,
+} from "../trust/Principal.ts";
+import * as Verify from "../trust/Verify.ts";
+
+export interface ExternalReview extends Review {
+  readonly principal: PrincipalId;
+}
+
+export interface RejectedExternalReview {
+  readonly commit: Oid;
+  readonly reason: string;
+  readonly quarantined: boolean;
+}
+
+export interface ExternalReviews {
+  readonly reviews: ReadonlyArray<ExternalReview>;
+  readonly rejected: ReadonlyArray<RejectedExternalReview>;
+}
+
+/**
+ * Read only explicitly attributed external review events.
+ *
+ * This is separate from the ordinary hub projection on purpose: resolving a
+ * key through an identity repository proves who spoke, but grants no project
+ * capability. Policy may opt in to counting the result later.
+ */
+export const externalReviews = Effect.fn("social.Review.externalReviews")(function* (
+  genesis: Genesis,
+  pullRequest: PullRequest,
+  pr: string,
+  options?: { readonly maxIdentityAgeMs?: number; readonly now?: Date },
+) {
+  const walked = yield* Event.entries(pr);
+  const latest = new Map<PrincipalId, ExternalReview>();
+  const rejected: RejectedExternalReview[] = [];
+
+  entries: for (const entry of walked.events) {
+    const payload = entry.payload;
+    if (
+      payload?.type !== "review.submitted" ||
+      payload.principal === undefined ||
+      !isPrincipalId(payload.principal)
+    ) {
+      continue;
+    }
+
+    const invalid = yield* Event.validate(payload, genesis.repoId).pipe(
+      Effect.as(null),
+      Effect.catchTag("Invalid", (error) => Effect.succeed(error.reason)),
+    );
+    if (invalid !== null) {
+      rejected.push({ commit: entry.commit, reason: invalid, quarantined: false });
+      continue;
+    }
+
+    const head = Event.unqualify(payload.head);
+    if (
+      head === null ||
+      pullRequest.head === null ||
+      head !== pullRequest.head ||
+      payload.base !== pullRequest.base
+    ) {
+      continue;
+    }
+
+    // Self-review is about the stable person, not one device fingerprint.
+    // Without this, opening from a laptop and approving from a phone counted
+    // as two people as soon as both keys belonged to one identity repository.
+    const localAuthors = new Set([
+      ...pullRequest.openers,
+      ...pullRequest.reviews.map((review) => review.author),
+    ]);
+    const localPrincipals = new Set([
+      ...pullRequest.openerPrincipals,
+      ...pullRequest.reviews.flatMap((review) =>
+        review.principal === null ? [] : [review.principal],
+      ),
+    ]);
+    if (localPrincipals.has(payload.principal)) {
+      rejected.push({
+        commit: entry.commit,
+        reason: `${payload.principal} already authored this proposal or a local review`,
+        quarantined: false,
+      });
+      continue;
+    }
+    for (const local of localAuthors) {
+      const relation = yield* containsIdentityKey(payload.principal, local);
+      if (relation.belongs) {
+        rejected.push({
+          commit: entry.commit,
+          reason: `${payload.principal} already authored this proposal or a local review`,
+          quarantined: false,
+        });
+        continue entries;
+      }
+    }
+
+    const signed = [...(yield* Verify.signers(entry.bytes, entry.signatures))].sort();
+    let author: Fingerprint | null = null;
+    let quarantine: string | null = null;
+    let moved: string | null = null;
+    for (const signer of signed) {
+      if (pullRequest.openers.has(signer)) continue;
+      const identity = yield* identifyKey({
+        principal: payload.principal,
+        signer,
+      });
+      if (identity.ok) {
+        if ((options?.maxIdentityAgeMs ?? 0) > 0) {
+          const freshness = Verify.fresh(
+            identity.identity.projection,
+            options?.maxIdentityAgeMs ?? 0,
+            options?.now ?? new Date(),
+          );
+          if (!freshness.ok) {
+            moved = `${payload.principal}'s identity view is stale: ${freshness.reason}`;
+            continue;
+          }
+        }
+        if (identity.identity.head !== payload.identityHead) {
+          moved = `${payload.principal} is now at ${identity.identity.head ?? "an empty log"}, not the pinned identity head ${payload.identityHead ?? "none"}`;
+          continue;
+        }
+        author = signer;
+        break;
+      }
+      if (identity.quarantined) quarantine ??= identity.reason;
+    }
+    if (author === null) {
+      rejected.push({
+        commit: entry.commit,
+        reason:
+          moved ?? quarantine ?? `${payload.principal} did not sign with a current identity key`,
+        quarantined: quarantine !== null,
+      });
+      continue;
+    }
+
+    latest.set(payload.principal, {
+      principal: payload.principal,
+      id: payload.id,
+      author,
+      head,
+      base: payload.base,
+      commit: entry.commit,
+      decision: payload.decision,
+      body: payload.body,
+      at: new Date(payload.issuedAt),
+      dismissed: false,
+      stale: false,
+    });
+  }
+
+  return {
+    reviews: [...latest.values()].filter((review) => review.decision === "approve"),
+    rejected,
+  } satisfies ExternalReviews;
+});

--- a/src/social/Statement.test.ts
+++ b/src/social/Statement.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect } from "effect";
+
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId } from "../trust/Principal.ts";
+import {
+  attestExternalIdentity,
+  attestRepo,
+  decode,
+  encode,
+  validate,
+  vouch,
+} from "./Statement.ts";
+
+/** SAFETY: forty-three base64 characters after `SHA256:`, which is the shape. */
+const repoId = (seed: string): RepoId => `SHA256:${seed.repeat(43).slice(0, 43)}` as RepoId;
+
+const alice = principalId(repoId("a"));
+const bob = principalId(repoId("b"));
+const project = repoId("c");
+const id = "018bcfe5-6800-7000-8000-000000000001";
+const at = new Date("2026-08-20T00:00:00.000Z");
+
+describe("social statements", () => {
+  it.effect("round-trips a canonical repository attestation", () =>
+    Effect.promise(async () => {
+      const statement = attestRepo({
+        author: alice,
+        id,
+        socialHead: null,
+        trustHead: null,
+        repo: project,
+        urls: ["https://git.example.com/acme/project"],
+        role: "origin",
+        forkOf: null,
+        lineage: `sha1:${"a1".repeat(20)}`,
+        inbox: "https://git.example.com/acme/project/inbox",
+        at,
+      });
+
+      const bytes = encode(statement);
+      const decoded = await Effect.runPromise(
+        Effect.gen(function* () {
+          const payload = yield* decode(bytes);
+          yield* validate(payload, alice);
+          return payload;
+        }),
+      );
+
+      assert.deepEqual(decoded, statement);
+      assert.equal(
+        new TextDecoder().decode(bytes),
+        `${JSON.stringify(
+          {
+            version: 1,
+            type: "social.attest.repo",
+            author: alice,
+            id,
+            issuedAt: at.toISOString(),
+            socialHead: null,
+            trustHead: null,
+            repo: project,
+            urls: ["https://git.example.com/acme/project"],
+            role: "origin",
+            forkOf: null,
+            lineage: `sha1:${"a1".repeat(20)}`,
+            inbox: "https://git.example.com/acme/project/inbox",
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    }),
+  );
+
+  it.effect("binds every statement to the identity repository that carries it", () =>
+    Effect.promise(async () => {
+      const statement = attestRepo({
+        author: alice,
+        id,
+        socialHead: null,
+        trustHead: null,
+        repo: project,
+        urls: ["https://git.example.com/acme/project"],
+        role: "origin",
+        at,
+      });
+
+      const failure = await Effect.runPromise(validate(statement, bob).pipe(Effect.flip));
+      assert.match(failure.reason, /author.*identity repository/i);
+    }),
+  );
+
+  it.effect("keeps external identities as proof-backed claims, not principal names", () =>
+    Effect.promise(async () => {
+      const statement = attestExternalIdentity({
+        author: alice,
+        id,
+        socialHead: null,
+        trustHead: null,
+        subject: bob,
+        identity: "github:bob",
+        proof: "https://gist.github.com/bob/proof",
+        at,
+      });
+
+      const decoded = await Effect.runPromise(decode(encode(statement)));
+      assert.equal(decoded.type, "social.attest.principal");
+      assert.equal(decoded.claim, "external-identity");
+      assert.equal(decoded.subject, `principal:${bob}`);
+    }),
+  );
+
+  it.effect("refuses a vouch that can widen into an unknown scope", () =>
+    Effect.promise(async () => {
+      const statement = {
+        ...vouch({
+          author: alice,
+          id,
+          socialHead: null,
+          trustHead: null,
+          subject: bob,
+          scope: ["review"],
+          depth: 1,
+          at,
+        }),
+        scope: ["review", "repo.admin"],
+      };
+
+      const failure = await Effect.runPromise(validate(statement, alice).pipe(Effect.flip));
+      assert.match(failure.reason, /unknown social scope/);
+    }),
+  );
+});

--- a/src/social/Statement.ts
+++ b/src/social/Statement.ts
@@ -1,0 +1,518 @@
+/** Signed statements carried by a principal's append-only social log. */
+import { Effect, Result, Schema } from "effect";
+
+import { parsePublicKey } from "../crypto/SshSignature.ts";
+import { Invalid } from "../git/Error.ts";
+import { isOid } from "../git/Store.ts";
+import { isRepoId, type RepoId } from "../trust/Genesis.ts";
+import {
+  isPrincipalId,
+  principalOf,
+  principalSubject,
+  type PrincipalId,
+} from "../trust/Principal.ts";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export const SOCIAL_SCOPES = ["introduce.repo", "introduce.key", "review", "vouch"] as const;
+export type SocialScope = (typeof SOCIAL_SCOPES)[number];
+const socialScopes = new Set<string>(SOCIAL_SCOPES);
+
+const envelope = {
+  version: Schema.Literal(1),
+  author: Schema.String,
+  id: Schema.String,
+  issuedAt: Schema.String,
+  socialHead: Schema.NullOr(Schema.String),
+  trustHead: Schema.NullOr(Schema.String),
+};
+
+export const AttestRepo = Schema.Struct({
+  type: Schema.tag("social.attest.repo"),
+  ...envelope,
+  repo: Schema.String,
+  urls: Schema.Array(Schema.String),
+  role: Schema.Literals(["origin", "mirror", "fork"]),
+  forkOf: Schema.NullOr(Schema.String),
+  lineage: Schema.NullOr(Schema.String),
+  inbox: Schema.NullOr(Schema.String),
+});
+
+/**
+ * One schema for both claim kinds keeps `type` globally unique in the tagged
+ * union. `validate` is where the mutually-exclusive fields are enforced.
+ */
+export const AttestPrincipal = Schema.Struct({
+  type: Schema.tag("social.attest.principal"),
+  ...envelope,
+  subject: Schema.String,
+  claim: Schema.Literals(["key-of", "external-identity"]),
+  publicKey: Schema.optional(Schema.String),
+  identity: Schema.optional(Schema.String),
+  proof: Schema.optional(Schema.String),
+});
+
+export const MirrorLocation = Schema.Struct({
+  url: Schema.String,
+  mode: Schema.Literals(["read", "write"]),
+});
+
+export const Mirrors = Schema.Struct({
+  type: Schema.tag("social.mirrors"),
+  ...envelope,
+  repo: Schema.String,
+  urls: Schema.Array(MirrorLocation),
+});
+
+export const Vouch = Schema.Struct({
+  type: Schema.tag("social.vouch"),
+  ...envelope,
+  subject: Schema.String,
+  scope: Schema.Array(Schema.String),
+  depth: Schema.Int,
+  expiresAt: Schema.NullOr(Schema.String),
+});
+
+export const Follow = Schema.Struct({
+  type: Schema.tag("social.follow"),
+  ...envelope,
+  subject: Schema.String,
+  petname: Schema.String,
+});
+
+export const Label = Schema.Struct({
+  type: Schema.tag("social.label"),
+  ...envelope,
+  subject: Schema.String,
+  namespace: Schema.String,
+  label: Schema.String,
+});
+
+export const Revoke = Schema.Struct({
+  type: Schema.tag("social.revoke"),
+  ...envelope,
+  target: Schema.String,
+  reason: Schema.Literals(["withdrawn", "superseded", "compromised"]),
+  compromisedAt: Schema.NullOr(Schema.String),
+});
+
+export const Checkpoint = Schema.Struct({
+  type: Schema.tag("social.checkpoint"),
+  ...envelope,
+  frontier: Schema.Array(Schema.String),
+});
+
+export const SocialStatement = Schema.Union([
+  AttestRepo,
+  AttestPrincipal,
+  Mirrors,
+  Vouch,
+  Follow,
+  Label,
+  Revoke,
+  Checkpoint,
+]).pipe(Schema.toTaggedUnion("type"));
+
+export type AttestRepo = (typeof AttestRepo)["Type"];
+export type AttestPrincipal = (typeof AttestPrincipal)["Type"];
+export type Mirrors = (typeof Mirrors)["Type"];
+export type Vouch = (typeof Vouch)["Type"];
+export type Follow = (typeof Follow)["Type"];
+export type Label = (typeof Label)["Type"];
+export type Revoke = (typeof Revoke)["Type"];
+export type Checkpoint = (typeof Checkpoint)["Type"];
+export type SocialStatement = (typeof SocialStatement)["Type"];
+
+const decodeStatement = Schema.decodeUnknownEffect(SocialStatement);
+
+export interface StatementContext {
+  readonly author: PrincipalId;
+  readonly id: string;
+  readonly socialHead: string | null;
+  readonly trustHead: string | null;
+  readonly at?: Date;
+}
+
+const common = (input: StatementContext) => ({
+  version: 1 as const,
+  author: input.author,
+  id: input.id,
+  issuedAt: (input.at ?? new Date()).toISOString(),
+  socialHead: input.socialHead,
+  trustHead: input.trustHead,
+});
+
+export const attestRepo = (
+  input: StatementContext & {
+    readonly repo: RepoId;
+    readonly urls: ReadonlyArray<string>;
+    readonly role: AttestRepo["role"];
+    readonly forkOf?: RepoId | null;
+    readonly lineage?: string | null;
+    readonly inbox?: string | null;
+  },
+): AttestRepo => ({
+  type: "social.attest.repo",
+  ...common(input),
+  repo: input.repo,
+  urls: input.urls,
+  role: input.role,
+  forkOf: input.forkOf ?? null,
+  lineage: input.lineage ?? null,
+  inbox: input.inbox ?? null,
+});
+
+export const attestPrincipalKey = (
+  input: StatementContext & { readonly subject: PrincipalId; readonly publicKey: string },
+): AttestPrincipal => ({
+  type: "social.attest.principal",
+  ...common(input),
+  subject: principalSubject(input.subject),
+  claim: "key-of",
+  publicKey: input.publicKey,
+});
+
+export const attestExternalIdentity = (
+  input: StatementContext & {
+    readonly subject: PrincipalId;
+    readonly identity: string;
+    readonly proof: string;
+  },
+): AttestPrincipal => ({
+  type: "social.attest.principal",
+  ...common(input),
+  subject: principalSubject(input.subject),
+  claim: "external-identity",
+  identity: input.identity,
+  proof: input.proof,
+});
+
+export const mirrors = (
+  input: StatementContext & {
+    readonly repo: "self" | RepoId;
+    readonly urls: Mirrors["urls"];
+  },
+): Mirrors => ({ type: "social.mirrors", ...common(input), repo: input.repo, urls: input.urls });
+
+export const vouch = (
+  input: StatementContext & {
+    readonly subject: PrincipalId;
+    readonly scope: ReadonlyArray<SocialScope>;
+    readonly depth: number;
+    readonly expiresAt?: Date | null;
+  },
+): Vouch => ({
+  type: "social.vouch",
+  ...common(input),
+  subject: principalSubject(input.subject),
+  scope: input.scope,
+  depth: input.depth,
+  expiresAt: input.expiresAt?.toISOString() ?? null,
+});
+
+export const follow = (
+  input: StatementContext & { readonly subject: PrincipalId; readonly petname: string },
+): Follow => ({
+  type: "social.follow",
+  ...common(input),
+  subject: principalSubject(input.subject),
+  petname: input.petname,
+});
+
+export const label = (
+  input: StatementContext & {
+    readonly subject: string;
+    readonly namespace: string;
+    readonly label: string;
+  },
+): Label => ({
+  type: "social.label",
+  ...common(input),
+  subject: input.subject,
+  namespace: input.namespace,
+  label: input.label,
+});
+
+export const revoke = (
+  input: StatementContext & {
+    readonly target: string;
+    readonly reason?: Revoke["reason"];
+    readonly compromisedAt?: Date | null;
+  },
+): Revoke => ({
+  type: "social.revoke",
+  ...common(input),
+  target: input.target,
+  reason: input.reason ?? "withdrawn",
+  compromisedAt: input.compromisedAt?.toISOString() ?? null,
+});
+
+export const checkpoint = (
+  input: StatementContext & { readonly frontier: ReadonlyArray<string> },
+): Checkpoint => ({
+  type: "social.checkpoint",
+  ...common(input),
+  frontier: input.frontier,
+});
+
+/** Canonical bytes: the common envelope first, then variant fields. */
+export const encode = (statement: SocialStatement): Uint8Array => {
+  const base = {
+    version: statement.version,
+    type: statement.type,
+    author: statement.author,
+    id: statement.id,
+    issuedAt: statement.issuedAt,
+    socialHead: statement.socialHead,
+    trustHead: statement.trustHead,
+  };
+
+  const ordered =
+    statement.type === "social.attest.repo"
+      ? {
+          ...base,
+          repo: statement.repo,
+          urls: statement.urls,
+          role: statement.role,
+          forkOf: statement.forkOf,
+          lineage: statement.lineage,
+          inbox: statement.inbox,
+        }
+      : statement.type === "social.attest.principal"
+        ? statement.claim === "key-of"
+          ? {
+              ...base,
+              subject: statement.subject,
+              claim: statement.claim,
+              publicKey: statement.publicKey,
+            }
+          : {
+              ...base,
+              subject: statement.subject,
+              claim: statement.claim,
+              identity: statement.identity,
+              proof: statement.proof,
+            }
+        : statement.type === "social.mirrors"
+          ? { ...base, repo: statement.repo, urls: statement.urls }
+          : statement.type === "social.vouch"
+            ? {
+                ...base,
+                subject: statement.subject,
+                scope: statement.scope,
+                depth: statement.depth,
+                expiresAt: statement.expiresAt,
+              }
+            : statement.type === "social.follow"
+              ? { ...base, subject: statement.subject, petname: statement.petname }
+              : statement.type === "social.label"
+                ? {
+                    ...base,
+                    subject: statement.subject,
+                    namespace: statement.namespace,
+                    label: statement.label,
+                  }
+                : statement.type === "social.revoke"
+                  ? {
+                      ...base,
+                      target: statement.target,
+                      reason: statement.reason,
+                      compromisedAt: statement.compromisedAt,
+                    }
+                  : { ...base, frontier: statement.frontier };
+
+  return encoder.encode(`${JSON.stringify(ordered, null, 2)}\n`);
+};
+
+export const decode = Effect.fn("social.Statement.decode")(function* (bytes: Uint8Array) {
+  const json = yield* Effect.try({
+    try: () => JSON.parse(decoder.decode(bytes)),
+    catch: () => new Invalid({ field: "statement", reason: "social statement is not valid JSON" }),
+  });
+  return yield* decodeStatement(json).pipe(
+    Effect.mapError(
+      (issue) =>
+        new Invalid({
+          field: "statement",
+          reason: `malformed social statement: ${issue.message}`,
+        }),
+    ),
+  );
+});
+
+const validUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const validId = (value: string): boolean =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value);
+
+/** Structural checks before a statement can affect any projection. */
+export const validate = Effect.fn("social.Statement.validate")(function* (
+  statement: SocialStatement,
+  identity: PrincipalId,
+) {
+  if (!isPrincipalId(statement.author) || statement.author !== identity) {
+    return yield* new Invalid({
+      field: "author",
+      reason: `author ${statement.author} is not this identity repository (${identity})`,
+    });
+  }
+  if (!validId(statement.id)) {
+    return yield* new Invalid({ field: "id", reason: `'${statement.id}' is not a UUIDv7` });
+  }
+  if (Number.isNaN(Date.parse(statement.issuedAt))) {
+    return yield* new Invalid({
+      field: "issuedAt",
+      reason: `not a date: '${statement.issuedAt}'`,
+    });
+  }
+  for (const [field, head] of [
+    ["socialHead", statement.socialHead],
+    ["trustHead", statement.trustHead],
+  ] as const) {
+    if (head !== null && !isOid(head)) {
+      return yield* new Invalid({ field, reason: `'${head}' is not an object id` });
+    }
+  }
+
+  if (statement.type === "social.attest.repo") {
+    if (!isRepoId(statement.repo)) {
+      return yield* new Invalid({ field: "repo", reason: `'${statement.repo}' is not a RepoID` });
+    }
+    if (statement.urls.length === 0 || statement.urls.some((url) => !validUrl(url))) {
+      return yield* new Invalid({ field: "urls", reason: "repo attestations need valid URLs" });
+    }
+    if (statement.role === "fork" ? !isRepoId(statement.forkOf ?? "") : statement.forkOf !== null) {
+      return yield* new Invalid({
+        field: "forkOf",
+        reason: "a fork must name its parent, and only a fork may name one",
+      });
+    }
+    if (statement.lineage !== null && !/^sha1:[0-9a-f]{40}$/.test(statement.lineage)) {
+      return yield* new Invalid({ field: "lineage", reason: "lineage must be a sha1 identifier" });
+    }
+    if (statement.inbox !== null && !validUrl(statement.inbox)) {
+      return yield* new Invalid({ field: "inbox", reason: "inbox must be a URL" });
+    }
+    return;
+  }
+
+  if (statement.type === "social.attest.principal") {
+    if (principalOf(statement.subject) === null) {
+      return yield* new Invalid({
+        field: "subject",
+        reason: `'${statement.subject}' is not a principal`,
+      });
+    }
+    if (statement.claim === "key-of") {
+      if (
+        statement.publicKey === undefined ||
+        statement.identity !== undefined ||
+        statement.proof !== undefined
+      ) {
+        return yield* new Invalid({
+          field: "claim",
+          reason: "a key-of claim carries only a public key",
+        });
+      }
+      if (Result.isFailure(parsePublicKey(statement.publicKey))) {
+        return yield* new Invalid({ field: "publicKey", reason: "not an SSH public key" });
+      }
+      return;
+    }
+    if (
+      statement.identity === undefined ||
+      !statement.identity.includes(":") ||
+      statement.proof === undefined ||
+      !validUrl(statement.proof) ||
+      statement.publicKey !== undefined
+    ) {
+      return yield* new Invalid({
+        field: "claim",
+        reason: "an external-identity claim needs a platform identity and proof URL",
+      });
+    }
+    return;
+  }
+
+  if (statement.type === "social.mirrors") {
+    if (statement.repo !== "self" && !isRepoId(statement.repo)) {
+      return yield* new Invalid({ field: "repo", reason: "a mirror must name self or a RepoID" });
+    }
+    if (
+      statement.urls.length === 0 ||
+      statement.urls.length > 8 ||
+      statement.urls.some(({ url }) => !validUrl(url))
+    ) {
+      return yield* new Invalid({ field: "urls", reason: "mirrors need one to eight valid URLs" });
+    }
+    return;
+  }
+
+  if (statement.type === "social.vouch") {
+    if (principalOf(statement.subject) === null) {
+      return yield* new Invalid({ field: "subject", reason: "a vouch must name a principal" });
+    }
+    const unknown = statement.scope.find((scope) => !socialScopes.has(scope));
+    if (unknown !== undefined) {
+      return yield* new Invalid({
+        field: "scope",
+        reason: `unknown social scope '${unknown}'`,
+      });
+    }
+    if (statement.scope.length === 0 || statement.depth < 0 || statement.depth > 16) {
+      return yield* new Invalid({
+        field: "depth",
+        reason: "a vouch needs a scope and a depth from 0 to 16",
+      });
+    }
+    if (statement.expiresAt !== null && Number.isNaN(Date.parse(statement.expiresAt))) {
+      return yield* new Invalid({ field: "expiresAt", reason: "not a date" });
+    }
+    return;
+  }
+
+  if (statement.type === "social.follow") {
+    if (principalOf(statement.subject) === null || statement.petname.trim() === "") {
+      return yield* new Invalid({
+        field: "follow",
+        reason: "a follow needs a principal and a non-empty petname",
+      });
+    }
+    return;
+  }
+
+  if (statement.type === "social.label") {
+    if (
+      !/^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i.test(statement.namespace) ||
+      statement.label.trim() === ""
+    ) {
+      return yield* new Invalid({
+        field: "label",
+        reason: "a label needs a reverse-domain namespace and a value",
+      });
+    }
+    return;
+  }
+
+  if (statement.type === "social.revoke") {
+    if (!validId(statement.target)) {
+      return yield* new Invalid({ field: "target", reason: "a revoke must name a statement id" });
+    }
+    if (statement.compromisedAt !== null && Number.isNaN(Date.parse(statement.compromisedAt))) {
+      return yield* new Invalid({ field: "compromisedAt", reason: "not a date" });
+    }
+    return;
+  }
+
+  if (statement.frontier.some((head) => !isOid(head))) {
+    return yield* new Invalid({ field: "frontier", reason: "a checkpoint frontier is object ids" });
+  }
+});

--- a/src/social/Sync.node.test.ts
+++ b/src/social/Sync.node.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect } from "effect";
+
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import type { Oid } from "../git/Store.ts";
+import type { RepoId } from "../trust/Genesis.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+import type { VerifiedLog, VerifiedStatement } from "./Log.ts";
+import { project } from "./Projection.ts";
+import { follow, mirrors, type SocialStatement } from "./Statement.ts";
+import { followedBy, locationOf } from "./Sync.node.ts";
+
+const repo = (seed: string): RepoId => {
+  // SAFETY: exactly forty-three base64 characters after the required prefix.
+  return `SHA256:${seed.repeat(43).slice(0, 43)}` as RepoId;
+};
+const principal = (seed: string): PrincipalId => principalId(repo(seed));
+const oid = (index: number): Oid => {
+  // SAFETY: exactly forty lowercase hexadecimal characters.
+  return index.toString(16).padStart(40, "0") as Oid;
+};
+const entry = (payload: SocialStatement, index: number): VerifiedStatement => ({
+  commit: oid(index),
+  parents: index === 1 ? [] : [oid(index - 1)],
+  payload,
+  bytes: new Uint8Array(),
+  signatures: [],
+  // SAFETY: exactly forty-three base64 characters after the required prefix.
+  signer: `SHA256:${"s".repeat(43)}` as Fingerprint,
+});
+const log = (owner: PrincipalId, statements: ReadonlyArray<SocialStatement>): VerifiedLog => ({
+  principal: owner,
+  head: statements.length === 0 ? null : oid(statements.length),
+  statements: statements.map(entry),
+  rejected: [],
+});
+const context = (author: PrincipalId, index: number) => ({
+  author,
+  id: `018bcfe5-6800-7000-8000-${index.toString().padStart(12, "0")}`,
+  socialHead: index === 1 ? null : oid(index - 1),
+  trustHead: null,
+  at: new Date(`2026-08-20T00:00:0${index}Z`),
+});
+
+describe("social synchronization", () => {
+  it.effect("crawls follow edges and prefers the subject's newest writable mirror", () =>
+    Effect.sync(() => {
+      const alice = principal("a");
+      const bob = principal("b");
+      const projection = project({
+        roots: [alice],
+        logs: [
+          log(alice, [follow({ ...context(alice, 1), subject: bob, petname: "bob" })]),
+          log(bob, [
+            mirrors({
+              ...context(bob, 1),
+              repo: "self",
+              urls: [{ url: "https://old.example/bob", mode: "read" }],
+            }),
+            mirrors({
+              ...context(bob, 2),
+              repo: "self",
+              urls: [
+                { url: "https://read.example/bob", mode: "read" },
+                { url: "https://write.example/bob", mode: "write" },
+              ],
+            }),
+          ]),
+        ],
+      });
+
+      assert.deepEqual(followedBy(projection, new Set([alice])), [bob]);
+      assert.equal(
+        locationOf(projection, bob, [
+          { url: "https://pinned.example/bob", repoId: bob, provenance: { kind: "tofu" } },
+        ]),
+        "https://write.example/bob",
+      );
+    }),
+  );
+});

--- a/src/social/Sync.node.ts
+++ b/src/social/Sync.node.ts
@@ -1,0 +1,168 @@
+/** Bounded follow-driven synchronization for identity repositories on Node. */
+import * as path from "node:path";
+
+import { Effect, Layer, Result } from "effect";
+
+import { fetchRepository } from "../client/Fetch.ts";
+import { Invalid } from "../git/Error.ts";
+import { stores } from "../git/Node.ts";
+import * as Refspec from "../git/Refspec.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { ObjectStore, RefStore } from "../git/Store.ts";
+import { reconcile } from "../server/Replication.ts";
+import { identityAt } from "../cli/remote-id.node.ts";
+import { GENESIS_REF, readGenesis } from "../trust/Genesis.ts";
+import type { KnownRepo } from "../trust/KnownRepos.ts";
+import { isPrincipalId, principalId, principalOf, type PrincipalId } from "../trust/Principal.ts";
+import { encodePrincipal } from "./Encode.ts";
+import * as Introduce from "./Introduce.ts";
+import type { Projection } from "./Projection.ts";
+import { identityRepositoryAt } from "./Web.node.ts";
+
+const localRepository = (directory: string) =>
+  GitRepository.layer.pipe(
+    Layer.provide(GitRepository.hooksNoop),
+    Layer.provideMerge(stores(directory)),
+  );
+
+/** Active follow targets published by the current traversal frontier. */
+export const followedBy = (
+  projection: Projection,
+  authors: ReadonlySet<PrincipalId>,
+): ReadonlyArray<PrincipalId> => {
+  const followed = new Set<PrincipalId>();
+  for (const statement of projection.active) {
+    if (
+      statement.payload.type !== "social.follow" ||
+      !isPrincipalId(statement.payload.author) ||
+      !authors.has(statement.payload.author)
+    ) {
+      continue;
+    }
+    const subject = principalOf(statement.payload.subject);
+    if (subject !== null) followed.add(subject);
+  }
+  return [...followed].sort();
+};
+
+/** Subject-published mirrors win over static pins and third-party attestations. */
+export const locationOf = (
+  projection: Projection,
+  subject: PrincipalId,
+  known: ReadonlyArray<KnownRepo>,
+): string | null => {
+  const self = projection.active
+    .filter(
+      (statement) =>
+        statement.payload.type === "social.mirrors" &&
+        statement.payload.author === subject &&
+        statement.payload.repo === "self",
+    )
+    .sort((left, right) =>
+      left.payload.issuedAt !== right.payload.issuedAt
+        ? right.payload.issuedAt.localeCompare(left.payload.issuedAt)
+        : left.commit < right.commit
+          ? -1
+          : 1,
+    )[0];
+  if (self?.payload.type === "social.mirrors") {
+    const preferred =
+      self.payload.urls.find((location) => location.mode === "write") ?? self.payload.urls[0];
+    if (preferred !== undefined) return preferred.url;
+  }
+
+  const pinned = known.find((entry) => entry.repoId === subject);
+  if (pinned !== undefined) return pinned.url;
+
+  return Introduce.repositories(projection).find((entry) => entry.repo === subject)?.url ?? null;
+};
+
+export interface SyncOutcome {
+  readonly principal: PrincipalId;
+  readonly url: string;
+  readonly directory: string;
+  readonly fetched: ReadonlyArray<string>;
+  readonly joined: ReadonlyArray<string>;
+}
+
+/** Verify the remote pin before allowing it to mutate a held identity clone. */
+export const syncIdentity = Effect.fn("social.Sync.syncIdentity")(function* (input: {
+  readonly root: string;
+  readonly principal: PrincipalId;
+  readonly url: string;
+  readonly token?: string | undefined;
+}) {
+  const presented = yield* Effect.tryPromise({
+    try: () => identityAt(input.url),
+    catch: (cause) =>
+      new Invalid({
+        field: "identity",
+        reason: `could not verify ${input.url}: ${cause instanceof Error ? cause.message : String(cause)}`,
+      }),
+  });
+  if (principalId(presented) !== input.principal) {
+    return yield* new Invalid({
+      field: "identity",
+      reason: `${input.url} presented ${presented}, expected ${input.principal}`,
+    });
+  }
+
+  const existing = yield* identityRepositoryAt(input.root, input.principal);
+  const encoded = encodePrincipal({ id: input.principal });
+  if (Result.isFailure(encoded)) return yield* encoded.failure;
+  const directory = path.join(input.root, existing ?? encoded.success);
+
+  // `social sync` itself runs inside the caller's identity repository. A
+  // nested provide merges with that ambient context and lets the ambient
+  // Repository win, so the followed clone must run in a fresh runtime.
+  const state = yield* Effect.tryPromise({
+    try: () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const target = { objects: yield* ObjectStore, refs: yield* RefStore };
+          const fetched: string[] = [];
+          const joined: string[] = [];
+          for (const spec of [
+            { force: false, source: GENESIS_REF, destination: GENESIS_REF },
+            { force: false, source: Refspec.TRUST_LOG, destination: Refspec.TRUST_LOG },
+            { force: false, source: Refspec.SOCIAL_LOG, destination: Refspec.SOCIAL_LOG },
+          ]) {
+            const result = yield* fetchRepository({
+              url: input.url,
+              token: input.token,
+              stores: target,
+              refspecs: [spec],
+            });
+            fetched.push(...result.refs.map((update) => update.name));
+            for (const rejected of result.rejected) {
+              if (rejected.name === GENESIS_REF) continue;
+              const divergence = yield* reconcile(rejected.name, rejected.oid);
+              if (divergence.joined !== null) joined.push(rejected.name);
+            }
+          }
+
+          const stored = yield* readGenesis();
+          if (stored === null || principalId(stored.genesis.repoId) !== input.principal) {
+            return yield* new Invalid({
+              field: "identity",
+              reason: `${directory} does not hold the verified identity after synchronization`,
+            });
+          }
+          return { fetched, joined };
+        }).pipe(Effect.provide(localRepository(directory))),
+      ),
+    catch: (cause) =>
+      new Invalid({
+        field: "sync",
+        reason: cause instanceof Error ? cause.message : String(cause),
+      }),
+  });
+
+  return {
+    principal: input.principal,
+    url: input.url,
+    directory,
+    fetched: state.fetched,
+    joined: state.joined,
+  } satisfies SyncOutcome;
+});

--- a/src/social/Web.node.ts
+++ b/src/social/Web.node.ts
@@ -1,0 +1,82 @@
+/** Verified social logs held as sibling repositories by a Node client. */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { Effect, Layer } from "effect";
+
+import { stores } from "../git/Node.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { readGenesis } from "../trust/Genesis.ts";
+import { principalId, type PrincipalId } from "../trust/Principal.ts";
+import { project as projectTrust } from "../trust/Projection.ts";
+import * as SocialLog from "./Log.ts";
+import { SocialWeb } from "./Projection.ts";
+
+const repositoryAt = (root: string, name: string) =>
+  GitRepository.layer.pipe(
+    Layer.provide(GitRepository.hooksNoop),
+    Layer.provide(stores(path.join(root, name))),
+  );
+
+const repositoryNames = (root: string) =>
+  Effect.promise(() =>
+    fs
+      .readdir(root, { withFileTypes: true })
+      .then((entries) =>
+        entries
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => entry.name)
+          .sort()
+          .slice(0, 4096),
+      )
+      .catch(() => []),
+  );
+
+/** Existing sibling directory holding exactly the requested identity. */
+export const identityRepositoryAt = Effect.fn("social.Web.identityRepositoryAt")(function* (
+  root: string,
+  wanted: PrincipalId,
+) {
+  for (const name of yield* repositoryNames(root)) {
+    const matches = yield* Effect.promise(() =>
+      Effect.runPromise(
+        readGenesis().pipe(
+          Effect.map((stored) => stored !== null && principalId(stored.genesis.repoId) === wanted),
+          Effect.provide(repositoryAt(root, name)),
+          Effect.catch(() => Effect.succeed(false)),
+        ),
+      ),
+    );
+    if (matches) return name;
+  }
+  return null;
+});
+
+/** Malformed or non-repository siblings are absence, never a broken graph. */
+export const verifiedLogsAt = Effect.fn("social.Web.verifiedLogsAt")(function* (root: string) {
+  const logs: SocialLog.VerifiedLog[] = [];
+  for (const name of yield* repositoryNames(root)) {
+    // A graph query itself runs inside the caller's identity repository. A
+    // nested `provide` is merged with that ambient context and the ambient
+    // Repository wins, making every sibling look like the caller. A fresh
+    // runtime is the isolation boundary between repositories here.
+    const log = yield* Effect.promise(() =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const stored = yield* readGenesis();
+          if (stored === null) return null;
+          const trust = yield* projectTrust(stored.genesis);
+          return yield* SocialLog.verified(stored.genesis, trust);
+        }).pipe(
+          Effect.provide(repositoryAt(root, name)),
+          Effect.catch(() => Effect.succeed(null)),
+        ),
+      ),
+    );
+    if (log !== null) logs.push(log);
+  }
+  return logs;
+});
+
+export const localSocialWeb = (root: string): Layer.Layer<SocialWeb> =>
+  Layer.succeed(SocialWeb)({ logs: verifiedLogsAt(root) });

--- a/src/trust/Certificate.ts
+++ b/src/trust/Certificate.ts
@@ -23,6 +23,12 @@ import {
 } from "../crypto/SshSignature.ts";
 import { Invalid } from "../git/Error.ts";
 import type { RepoId } from "./Genesis.ts";
+import {
+  principalOf,
+  principalSubject,
+  type PrincipalId,
+  type PrincipalSubject,
+} from "./Principal.ts";
 
 /**
  * The capabilities this version knows, minus the scoped ones.
@@ -56,6 +62,7 @@ export const CAPABILITIES = [
   "hub.redact",
   "hub.session",
   "hub.task",
+  "social.write",
   "member.invite",
   "member.revoke",
   "policy.write",
@@ -123,13 +130,20 @@ const envelope = {
   issuedAt: Timestamp,
 };
 
+export const IdentityRepo = Schema.Struct({
+  pin: Schema.String,
+  hint: Schema.Array(Schema.String),
+});
+
 export const Grant = Schema.Struct({
   type: Schema.tag("trust.grant"),
   ...envelope,
-  /** The subject key's fingerprint: what every later record names it by. */
+  /** A key fingerprint, or `principal:<PrincipalID>`. */
   subject: Schema.String,
-  /** The `authorized_keys` line, so a verifier needs nothing else to check it. */
-  publicKey: Schema.String,
+  /** Present for a key grant and absent for a principal grant. */
+  publicKey: Schema.optional(Schema.String),
+  /** Present for a principal grant and absent for a key grant. */
+  identityRepo: Schema.optional(IdentityRepo),
   capabilities: Schema.Array(Schema.String),
   /** `null` never expires; collaborative repositories should set one. */
   expiresAt: Schema.NullOr(Timestamp),
@@ -232,7 +246,9 @@ export const encode = (payload: TrustPayload): Uint8Array => {
       ? {
           ...common,
           subject: payload.subject,
-          publicKey: payload.publicKey,
+          ...(payload.publicKey === undefined
+            ? { identityRepo: payload.identityRepo }
+            : { publicKey: payload.publicKey }),
           capabilities: payload.capabilities,
           expiresAt: payload.expiresAt,
         }
@@ -304,9 +320,53 @@ export const grant = Effect.fn("Certificate.grant")(function* (input: {
   } satisfies Grant;
 });
 
+/** Build a grant whose subject is an identity repository, not one key. */
+export const grantPrincipal = Effect.fn("Certificate.grantPrincipal")(function* (input: {
+  readonly repo: RepoId;
+  readonly principal: PrincipalId;
+  readonly hints?: ReadonlyArray<string>;
+  readonly capabilities: ReadonlyArray<string>;
+  readonly expiresAt?: Date | null;
+  readonly id: string;
+  readonly at?: Date;
+}) {
+  for (const capability of input.capabilities) {
+    if (!isCapability(capability)) {
+      return yield* new Invalid({
+        field: "capabilities",
+        reason: `unknown capability '${capability}'`,
+      });
+    }
+  }
+  const hints = input.hints ?? [];
+  for (const hint of hints) {
+    const valid = yield* Effect.try({
+      try: () => {
+        const url = new URL(hint);
+        return url.protocol === "https:" || url.protocol === "http:";
+      },
+      catch: () => false,
+    });
+    if (!valid) {
+      return yield* new Invalid({ field: "identityRepo", reason: `'${hint}' is not a URL` });
+    }
+  }
+  return {
+    type: "trust.grant",
+    version: 1,
+    repo: input.repo,
+    id: input.id,
+    issuedAt: (input.at ?? new Date()).toISOString(),
+    subject: principalSubject(input.principal),
+    identityRepo: { pin: input.principal, hint: hints },
+    capabilities: input.capabilities,
+    expiresAt: input.expiresAt?.toISOString() ?? null,
+  } satisfies Grant;
+});
+
 export const revoke = (input: {
   readonly repo: RepoId;
-  readonly subject: Fingerprint;
+  readonly subject: Fingerprint | PrincipalSubject;
   readonly reason: Revoke["reason"];
   readonly compromisedAt?: Date | null;
   readonly id: string;
@@ -378,16 +438,48 @@ export const validate = Effect.fn("Certificate.validate")(function* (
   }
 
   if (payload.type === "trust.grant") {
-    const key = parsePublicKey(payload.publicKey);
-    if (Result.isFailure(key)) {
-      return yield* new Invalid({ field: "publicKey", reason: key.failure.reason });
-    }
-    const print = yield* fingerprint(key.success);
-    if (print !== payload.subject) {
-      return yield* new Invalid({
-        field: "subject",
-        reason: `subject ${payload.subject} is not the fingerprint of the key given (${print})`,
-      });
+    const principal = principalOf(payload.subject);
+    if (principal === null) {
+      if (payload.publicKey === undefined || payload.identityRepo !== undefined) {
+        return yield* new Invalid({
+          field: "publicKey",
+          reason: "a key grant carries a public key and no identity repository",
+        });
+      }
+      const key = parsePublicKey(payload.publicKey);
+      if (Result.isFailure(key)) {
+        return yield* new Invalid({ field: "publicKey", reason: key.failure.reason });
+      }
+      const print = yield* fingerprint(key.success);
+      if (print !== payload.subject) {
+        return yield* new Invalid({
+          field: "subject",
+          reason: `subject ${payload.subject} is not the fingerprint of the key given (${print})`,
+        });
+      }
+    } else {
+      if (
+        payload.publicKey !== undefined ||
+        payload.identityRepo === undefined ||
+        payload.identityRepo.pin !== principal
+      ) {
+        return yield* new Invalid({
+          field: "identityRepo",
+          reason: "a principal grant must pin the PrincipalID named by its subject",
+        });
+      }
+      for (const hint of payload.identityRepo.hint) {
+        const valid = yield* Effect.try({
+          try: () => {
+            const url = new URL(hint);
+            return url.protocol === "https:" || url.protocol === "http:";
+          },
+          catch: () => false,
+        });
+        if (!valid) {
+          return yield* new Invalid({ field: "identityRepo", reason: `'${hint}' is not a URL` });
+        }
+      }
     }
     for (const capability of payload.capabilities) {
       if (!isCapability(capability)) {
@@ -407,10 +499,10 @@ export const validate = Effect.fn("Certificate.validate")(function* (
   }
 
   if (payload.type === "trust.revoke") {
-    if (!isFingerprint(payload.subject)) {
+    if (!isFingerprint(payload.subject) && principalOf(payload.subject) === null) {
       return yield* new Invalid({
         field: "subject",
-        reason: `not a fingerprint: '${payload.subject}'`,
+        reason: `not a fingerprint or principal: '${payload.subject}'`,
       });
     }
     if (payload.compromisedAt !== null && Number.isNaN(Date.parse(payload.compromisedAt))) {

--- a/src/trust/KnownRepos.test.ts
+++ b/src/trust/KnownRepos.test.ts
@@ -160,6 +160,32 @@ describe("KnownRepos", () => {
       ];
       assert.deepEqual(parseFile(formatFile(entries)), entries);
     });
+
+    it("records whether a pin came from TOFU or an introduction", () => {
+      const entries = [
+        {
+          url: "https://git.example.com/tofu",
+          repoId: alpha,
+          provenance: { kind: "tofu" } as const,
+        },
+        {
+          url: "https://git.example.com/introduced",
+          repoId: beta,
+          provenance: { kind: "introduced", paths: 2 } as const,
+        },
+      ];
+
+      const encoded = formatFile(entries);
+      assert.match(encoded, new RegExp(`tofu\\s*$`, "m"));
+      assert.match(encoded, new RegExp(`introduced:2\\s*$`, "m"));
+      assert.deepEqual(parseFile(encoded), entries);
+    });
+
+    it("continues to read legacy two-column pins as implicit TOFU", () => {
+      assert.deepEqual(parseFile(`https://git.example.com/legacy ${alpha}\n`), [
+        { url: "https://git.example.com/legacy", repoId: alpha },
+      ]);
+    });
   });
 
   describe("the decision", () => {

--- a/src/trust/KnownRepos.ts
+++ b/src/trust/KnownRepos.ts
@@ -26,7 +26,13 @@ import { isRepoId, type RepoId } from "./Genesis.ts";
 export interface KnownRepo {
   readonly url: string;
   readonly repoId: RepoId;
+  /** Absent only for a legacy two-column entry, which means implicit TOFU. */
+  readonly provenance?: Provenance;
 }
+
+export type Provenance =
+  | { readonly kind: "tofu" }
+  | { readonly kind: "introduced"; readonly paths: number };
 
 export class KnownRepos extends Context.Service<
   KnownRepos,
@@ -146,12 +152,34 @@ export const parseLine = (line: string): KnownRepo | null => {
   const trimmed = line.trim();
   if (trimmed === "" || trimmed.startsWith("#")) return null;
 
-  const [url, repoId] = trimmed.split(/\s+/);
+  const [url, repoId, encodedProvenance] = trimmed.split(/\s+/);
   if (url === undefined || repoId === undefined) return null;
-  return isRepoId(repoId) ? { url, repoId } : null;
+  if (!isRepoId(repoId)) return null;
+
+  if (encodedProvenance === "tofu") return { url, repoId, provenance: { kind: "tofu" } };
+  const introduced = /^introduced:([1-9][0-9]*)$/.exec(encodedProvenance ?? "");
+  if (introduced !== null) {
+    return {
+      url,
+      repoId,
+      provenance: { kind: "introduced", paths: Number(introduced[1]) },
+    };
+  }
+  // A missing column is the v1 format and means TOFU. An unrecognised future
+  // column is kept implicit too: forgetting the whole line would forget the
+  // pin and turn an identity change into a first-use prompt.
+  return { url, repoId };
 };
 
-export const formatLine = (entry: KnownRepo): string => `${entry.url} ${entry.repoId}`;
+export const formatLine = (entry: KnownRepo): string => {
+  const provenance =
+    entry.provenance === undefined
+      ? ""
+      : entry.provenance.kind === "tofu"
+        ? " tofu"
+        : ` introduced:${entry.provenance.paths}`;
+  return `${entry.url} ${entry.repoId}${provenance}`;
+};
 
 export const parseFile = (contents: string): ReadonlyArray<KnownRepo> => {
   const entries: KnownRepo[] = [];

--- a/src/trust/Principal.test.ts
+++ b/src/trust/Principal.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+
+import { Effect, Layer } from "effect";
+
+import { fingerprint, formatPublicKey, generate, NAMESPACE, sign } from "../crypto/SshSignature.ts";
+import { EMPTY_TREE_OID } from "../git/Format.ts";
+import { stores } from "../git/Memory.ts";
+import * as GitRepository from "../git/Repository.ts";
+import { Repository } from "../git/Repository.ts";
+import * as PullRequest from "../hub/PullRequest.ts";
+import { approvals, project as projectPullRequest } from "../hub/Projection.ts";
+import * as Certificate from "./Certificate.ts";
+import { create, signGenesis, writeGenesis } from "./Genesis.ts";
+import * as Log from "./Log.ts";
+import {
+  authorizeKey,
+  identitiesInMemory,
+  identifyKey,
+  principalId,
+  type ResolvedIdentity,
+} from "./Principal.ts";
+import { project } from "./Projection.ts";
+import * as Verify from "./Verify.ts";
+
+const scenario = <A, E>(effect: Effect.Effect<A, E, Repository>) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        GitRepository.layer.pipe(Layer.provide(GitRepository.hooksNoop), Layer.provide(stores)),
+      ),
+    ),
+  );
+
+describe("principal membership", () => {
+  it.effect("resolves a project grant through the principal's current identity log", () =>
+    Effect.promise(async () => {
+      const identity = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("identity-root@example.com");
+          const oldDevice = yield* generate("old-device@example.com");
+          const newDevice = yield* generate("new-device@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+
+          const oldGrant = yield* Certificate.grant({
+            repo: genesis.repoId,
+            publicKey: formatPublicKey(oldDevice.publicKey),
+            capabilities: [],
+            id: Log.newId(),
+          });
+          yield* Log.issue(oldGrant, [root]);
+          yield* Log.issue(
+            Certificate.revoke({
+              repo: genesis.repoId,
+              subject: oldGrant.subject,
+              reason: "rotated",
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(newDevice.publicKey),
+              capabilities: [],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+
+          return {
+            id: principalId(genesis.repoId),
+            key: newDevice,
+            old: yield* fingerprint(oldDevice.publicKey),
+            current: yield* fingerprint(newDevice.publicKey),
+            projection: yield* project(genesis),
+          };
+        }),
+      );
+
+      const resolved: ResolvedIdentity = {
+        principal: identity.id,
+        projection: identity.projection,
+        head: identity.projection.head,
+      };
+      const result = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("project-root@example.com");
+          const marker = yield* generate("marker@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          const beforeGrant = yield* Log.issue(
+            yield* Certificate.grant({
+              repo: genesis.repoId,
+              publicKey: formatPublicKey(marker.publicKey),
+              capabilities: [],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const principalGrant = yield* Log.issue(
+            yield* Certificate.grantPrincipal({
+              repo: genesis.repoId,
+              principal: identity.id,
+              hints: ["https://identity.example/alice"],
+              capabilities: ["source.push"],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const projectProjection = yield* project(genesis);
+          const bytes = new TextEncoder().encode("stored event");
+          const signature = yield* sign(identity.key, bytes, NAMESPACE);
+          return {
+            old: yield* authorizeKey({
+              projection: projectProjection,
+              signer: identity.old,
+              capability: "source.push",
+            }),
+            current: yield* authorizeKey({
+              projection: projectProjection,
+              signer: identity.current,
+              capability: "source.push",
+            }),
+            boundary: yield* Verify.authorizeKey({
+              projection: projectProjection,
+              signer: identity.current,
+              capability: "source.push",
+            }),
+            identityOnly: yield* identifyKey({
+              principal: identity.id,
+              signer: identity.current,
+            }),
+            beforeGrant: yield* Verify.authorize({
+              projection: projectProjection,
+              bytes,
+              signatures: [signature],
+              capability: "source.push",
+              made: { at: new Date(), trustHead: beforeGrant },
+            }),
+            afterGrant: yield* Verify.authorize({
+              projection: projectProjection,
+              bytes,
+              signatures: [signature],
+              capability: "source.push",
+              made: { at: new Date(), trustHead: principalGrant },
+            }),
+          };
+        }).pipe(Effect.provide(identitiesInMemory([resolved]))),
+      );
+
+      assert.equal(result.old.ok, false, "one identity-log revocation reaches every project grant");
+      assert.equal(result.current.ok, true);
+      assert.equal(result.current.ok ? result.current.identity.principal : null, identity.id);
+      assert.equal(result.boundary.ok, true, "the normal policy/auth seam resolves principals too");
+      assert.equal(result.identityOnly.ok, true, "an external statement can prove identity alone");
+      assert.equal(
+        result.beforeGrant.ok,
+        false,
+        "granting a PrincipalID does not retroactively authorize its old signatures",
+      );
+      assert.equal(result.afterGrant.ok, true, "the grant applies once the event reaches it");
+      assert.equal(
+        result.afterGrant.ok ? result.afterGrant.identity?.principal : null,
+        identity.id,
+        "stored-event authorization retains the stable identity it resolved through",
+      );
+    }),
+  );
+
+  it.effect("does not count two devices of one PrincipalID as independent self-review", () =>
+    Effect.promise(async () => {
+      const identity = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("identity-root@example.com");
+          const laptop = yield* generate("laptop@example.com");
+          const phone = yield* generate("phone@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          for (const device of [laptop, phone]) {
+            yield* Log.issue(
+              yield* Certificate.grant({
+                repo: genesis.repoId,
+                publicKey: formatPublicKey(device.publicKey),
+                capabilities: [],
+                id: Log.newId(),
+              }),
+              [root],
+            );
+          }
+          const projection = yield* project(genesis);
+          return {
+            laptop,
+            phone,
+            resolved: {
+              principal: principalId(genesis.repoId),
+              projection,
+              head: projection.head,
+            } satisfies ResolvedIdentity,
+          };
+        }),
+      );
+
+      const result = await scenario(
+        Effect.gen(function* () {
+          const root = yield* generate("project-root@example.com");
+          const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+          yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+          yield* Log.issue(
+            yield* Certificate.grantPrincipal({
+              repo: genesis.repoId,
+              principal: identity.resolved.principal,
+              capabilities: ["hub.create-pr", "hub.approve"],
+              id: Log.newId(),
+            }),
+            [root],
+          );
+          const opened = yield* PullRequest.open({
+            repo: genesis.repoId,
+            title: "same person, two devices",
+            base: "refs/heads/main",
+            head: EMPTY_TREE_OID,
+            key: identity.laptop,
+          });
+          yield* PullRequest.review({
+            repo: genesis.repoId,
+            pr: opened.pr,
+            head: EMPTY_TREE_OID,
+            decision: "approve",
+            key: identity.phone,
+          });
+          const state = yield* projectPullRequest(genesis, yield* project(genesis), opened.pr);
+          return { state, approvals: approvals(state) };
+        }).pipe(Effect.provide(identitiesInMemory([identity.resolved]))),
+      );
+
+      assert.equal(result.state.openerPrincipals.has(identity.resolved.principal), true);
+      assert.equal(result.state.reviews[0]?.principal, identity.resolved.principal);
+      assert.equal(result.approvals.length, 0);
+    }),
+  );
+
+  it.effect(
+    "quarantines rather than rejects when an identity repository is not available yet",
+    () =>
+      Effect.promise(async () => {
+        const outcome = await scenario(
+          Effect.gen(function* () {
+            const root = yield* generate("project-root@example.com");
+            const device = yield* generate("device@example.com");
+            const identityGenesis = yield* create([formatPublicKey(device.publicKey)], 1);
+            const genesis = yield* create([formatPublicKey(root.publicKey)], 1);
+            yield* writeGenesis(genesis, [yield* signGenesis(genesis, root)]);
+            yield* Log.issue(
+              yield* Certificate.grantPrincipal({
+                repo: genesis.repoId,
+                principal: principalId(identityGenesis.repoId),
+                capabilities: ["hub.review"],
+                id: Log.newId(),
+              }),
+              [root],
+            );
+            return yield* authorizeKey({
+              projection: yield* project(genesis),
+              signer: yield* fingerprint(device.publicKey),
+              capability: "hub.review",
+            });
+          }),
+        );
+
+        assert.equal(outcome.ok, false);
+        assert.equal(outcome.ok ? false : outcome.quarantined, true);
+      }),
+  );
+});

--- a/src/trust/Principal.ts
+++ b/src/trust/Principal.ts
@@ -1,0 +1,308 @@
+/**
+ * Stable identities built from identity repositories.
+ *
+ * A principal identifier has the same bytes as a repository identifier. The
+ * separate brand prevents an API that expects "who" from silently accepting
+ * "which project"; payloads that name a principal use the explicit
+ * `principal:` subject spelling.
+ */
+import { Context, Effect, Layer, Option } from "effect";
+
+import type { Fingerprint } from "../crypto/SshSignature.ts";
+import type { Oid } from "../git/Store.ts";
+import { isRepoId, type RepoId } from "./Genesis.ts";
+import type { Member, PrincipalMember, Projection } from "./Projection.ts";
+
+export type PrincipalId = RepoId & { readonly PrincipalId: unique symbol };
+export type PrincipalSubject = string & { readonly PrincipalSubject: unique symbol };
+
+/** A repository identity viewed as the identity repository of a principal. */
+export const principalId = (repo: RepoId): PrincipalId => {
+  // SAFETY: a PrincipalID is defined as the RepoID of an identity repository;
+  // the caller is making that semantic choice explicitly at this boundary.
+  return repo as PrincipalId;
+};
+
+export const isPrincipalId = (value: string): value is PrincipalId => isRepoId(value);
+
+export const principalSubject = (principal: PrincipalId): PrincipalSubject => {
+  // SAFETY: the prefix and the validated PrincipalID are exactly the branded
+  // subject representation this module owns.
+  return `principal:${principal}` as PrincipalSubject;
+};
+
+export const principalOf = (subject: string): PrincipalId | null => {
+  if (!subject.startsWith("principal:")) return null;
+  const value = subject.slice("principal:".length);
+  return isPrincipalId(value) ? value : null;
+};
+
+export interface ResolvedIdentity {
+  readonly principal: PrincipalId;
+  readonly projection: Projection;
+  /** The identity trust-log head the projection was built from. */
+  readonly head: Oid | null;
+}
+
+/** Identity repositories already fetched and verified by the caller. */
+export class Identities extends Context.Service<
+  Identities,
+  {
+    readonly resolve: (principal: PrincipalId) => Effect.Effect<ResolvedIdentity | null>;
+  }
+>()("trust/Identities") {}
+
+export const identitiesInMemory = (
+  identities: ReadonlyArray<ResolvedIdentity>,
+): Layer.Layer<Identities> => {
+  const byPrincipal = new Map(
+    identities.map((identity) => [identity.principal, identity] as const),
+  );
+  return Layer.succeed(Identities)({
+    resolve: (principal) => Effect.succeed(byPrincipal.get(principal) ?? null),
+  });
+};
+
+/** Resolve one identity and reject a provider answer that does not match its pin. */
+const resolveVerified = Effect.fn("trust.Principal.resolveVerified")(function* (
+  service: Identities["Service"],
+  principal: PrincipalId,
+) {
+  const identity = yield* service.resolve(principal);
+  if (
+    identity === null ||
+    identity.principal !== principal ||
+    identity.projection.repoId !== principal ||
+    identity.projection.head !== identity.head
+  ) {
+    return null;
+  }
+  return identity;
+});
+
+const permits = (held: ReadonlyArray<string>, required: string): boolean => {
+  for (const capability of held) {
+    if (capability === "repo.admin" || capability === required) return true;
+    if (
+      capability === "hub.check:*" &&
+      required.startsWith("hub.check:") &&
+      required.length > "hub.check:".length
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export type PrincipalAuthorization =
+  | {
+      readonly ok: true;
+      /** A Member-shaped view for existing policy and hub consumers. */
+      readonly principal: Member;
+      readonly grant: PrincipalMember;
+      readonly identity: ResolvedIdentity;
+    }
+  | { readonly ok: false; readonly reason: string; readonly quarantined: boolean };
+
+const denied = (reason: string, quarantined = false): PrincipalAuthorization => ({
+  ok: false,
+  reason,
+  quarantined,
+});
+
+export type IdentityAuthorization =
+  | {
+      readonly ok: true;
+      readonly principal: PrincipalId;
+      readonly member: Member;
+      readonly identity: ResolvedIdentity;
+    }
+  | { readonly ok: false; readonly reason: string; readonly quarantined: boolean };
+
+export type IdentityKeyRelation =
+  | { readonly available: true; readonly belongs: boolean }
+  | { readonly available: false; readonly belongs: false };
+
+/** Whether a key has ever been a device of this stable identity. */
+export const containsIdentityKey = Effect.fn("trust.Principal.containsIdentityKey")(function* (
+  principal: PrincipalId,
+  signer: Fingerprint,
+) {
+  const service = yield* Effect.serviceOption(Identities);
+  if (Option.isNone(service)) return { available: false, belongs: false } as const;
+  const identity = yield* resolveVerified(service.value, principal);
+  if (identity === null) return { available: false, belongs: false } as const;
+  return {
+    available: true,
+    belongs: identity.projection.members.has(signer) || identity.projection.former.has(signer),
+  } as const;
+});
+
+/** Prove that a signing key is current for one specifically named identity. */
+export const identifyKey = Effect.fn("trust.Principal.identifyKey")(function* (input: {
+  readonly principal: PrincipalId;
+  readonly signer: Fingerprint;
+  readonly at?: Date;
+}) {
+  const service = yield* Effect.serviceOption(Identities);
+  if (Option.isNone(service)) {
+    return {
+      ok: false,
+      reason: "the referenced identity repository has not been synchronized",
+      quarantined: true,
+    } satisfies IdentityAuthorization;
+  }
+
+  const identity = yield* resolveVerified(service.value, input.principal);
+  if (identity === null) {
+    return {
+      ok: false,
+      reason: "the referenced identity repository has not been synchronized",
+      quarantined: true,
+    } satisfies IdentityAuthorization;
+  }
+
+  const member = identity.projection.members.get(input.signer);
+  const at = input.at ?? new Date();
+  if (
+    member === undefined ||
+    (member.expiresAt !== null && member.expiresAt.getTime() <= at.getTime())
+  ) {
+    return {
+      ok: false,
+      reason: `${input.signer} is not a current key of ${input.principal}`,
+      quarantined: false,
+    } satisfies IdentityAuthorization;
+  }
+
+  return {
+    ok: true,
+    principal: input.principal,
+    member,
+    identity,
+  } satisfies IdentityAuthorization;
+});
+
+export interface ResolvedPrincipalKey {
+  /** Member-shaped target-repository authority for existing consumers. */
+  readonly principal: Member;
+  readonly grant: PrincipalMember;
+  readonly identity: ResolvedIdentity;
+}
+
+export interface PrincipalKeyCandidates {
+  readonly matches: ReadonlyArray<ResolvedPrincipalKey>;
+  /** At least one relevant identity repository was not available or valid. */
+  readonly unavailable: boolean;
+}
+
+/**
+ * Resolve a key through every matching stable-identity grant.
+ *
+ * `includeFormer` is for a stored-event fold. It does not itself authorize a
+ * revoked grant; the caller still applies that grant's revocation window and
+ * trust-head ancestry. Returning all matches is important: one revoked
+ * principal must not hide a second, valid grant for the same device key.
+ */
+export const resolveKeyCandidates = Effect.fn("trust.Principal.resolveKeyCandidates")(
+  function* (input: {
+    readonly projection: Projection;
+    readonly signer: Fingerprint;
+    readonly includeFormer?: boolean;
+    readonly at?: Date;
+  }) {
+    const service = yield* Effect.serviceOption(Identities);
+    if (Option.isNone(service)) {
+      return { matches: [], unavailable: input.projection.principals.size > 0 };
+    }
+
+    const grants = new Map(input.projection.principals);
+    if (input.includeFormer === true) {
+      for (const [principal, grant] of input.projection.formerPrincipals) {
+        if (!grants.has(principal)) grants.set(principal, grant);
+      }
+    }
+
+    const at = input.at ?? new Date();
+    const matches: ResolvedPrincipalKey[] = [];
+    let unavailable = false;
+    for (const grant of grants.values()) {
+      const identity = yield* resolveVerified(service.value, grant.principal);
+      if (identity === null) {
+        unavailable = true;
+        continue;
+      }
+
+      // A current device is the live path. For a stored event, a forward-only
+      // rotation may preserve what the device signed; compromise never does.
+      let device = identity.projection.members.get(input.signer);
+      if (device === undefined && input.includeFormer === true) {
+        const windows = identity.projection.revoked.get(input.signer);
+        const open = windows?.at(-1);
+        if (open !== undefined && open.supersededBy === null && open.reason !== "compromised") {
+          device = identity.projection.former.get(input.signer);
+        }
+      }
+      if (device === undefined) continue;
+      if (device.expiresAt !== null && device.expiresAt.getTime() <= at.getTime()) continue;
+
+      const expiresAt =
+        grant.expiresAt === null
+          ? device.expiresAt
+          : device.expiresAt === null || grant.expiresAt <= device.expiresAt
+            ? grant.expiresAt
+            : device.expiresAt;
+      matches.push({
+        grant,
+        identity,
+        principal: {
+          fingerprint: input.signer,
+          publicKey: device.publicKey,
+          capabilities: grant.capabilities,
+          grantedAt: grant.grantedAt,
+          expiresAt,
+          grant: grant.grant,
+          history: grant.history,
+        },
+      });
+    }
+    return { matches, unavailable } satisfies PrincipalKeyCandidates;
+  },
+);
+
+/**
+ * Resolve one presenting key through the stable identities granted here.
+ *
+ * An unavailable foreign log is quarantine: replication can bring it later
+ * and the same deterministic question can then be asked again. A resolved log
+ * in which the key is absent is a real denial.
+ */
+export const authorizeKey = Effect.fn("trust.Principal.authorizeKey")(function* (input: {
+  readonly projection: Projection;
+  readonly signer: Fingerprint;
+  readonly capability: string;
+  readonly at?: Date;
+}) {
+  const at = input.at ?? new Date();
+  const eligible = [...input.projection.principals.values()].filter((grant) =>
+    permits(grant.capabilities, input.capability),
+  );
+  if (eligible.length === 0) {
+    return denied(`${input.signer} is not a member of this repository`);
+  }
+
+  const resolved = yield* resolveKeyCandidates({
+    projection: input.projection,
+    signer: input.signer,
+    at,
+  });
+  for (const match of resolved.matches) {
+    if (!permits(match.grant.capabilities, input.capability)) continue;
+    if (match.grant.expiresAt !== null && match.grant.expiresAt.getTime() <= at.getTime()) continue;
+    return { ok: true, ...match } as const;
+  }
+
+  return resolved.unavailable
+    ? denied("a referenced identity repository has not been synchronized", true)
+    : denied(`${input.signer} is not a current key of any granted principal`);
+});

--- a/src/trust/Projection.ts
+++ b/src/trust/Projection.ts
@@ -29,6 +29,7 @@ import * as Certificate from "./Certificate.ts";
 import { MAX_SIGNATURES } from "./Certificate.ts";
 import { type Genesis, type RepoId, type RootKey } from "./Genesis.ts";
 import * as Log from "./Log.ts";
+import { principalOf, type PrincipalId } from "./Principal.ts";
 
 const decoder = new TextDecoder();
 
@@ -73,6 +74,25 @@ export interface Member {
 export interface GrantRecord {
   readonly commit: Oid;
   readonly capabilities: ReadonlyArray<string>;
+}
+
+/** A repository membership grant held by an identity repository. */
+export interface PrincipalMember {
+  readonly principal: PrincipalId;
+  readonly hints: ReadonlyArray<string>;
+  readonly capabilities: ReadonlyArray<string>;
+  readonly grantedAt: Date;
+  readonly expiresAt: Date | null;
+  readonly grant: Oid;
+  readonly history: ReadonlyArray<GrantRecord>;
+}
+
+export interface PrincipalRevocation {
+  readonly subject: PrincipalId;
+  readonly reason: Certificate.Revoke["reason"];
+  readonly compromisedFrom: Date | null;
+  readonly commit: Oid;
+  readonly supersededBy: Oid | null;
 }
 
 export interface Revocation {
@@ -122,9 +142,9 @@ const earliest = (left: Date | null, right: Date | null): Date | null => {
  * right now", and every earlier window stays on the record because it is still
  * true about its own interval.
  */
-export const openWindow = (
-  revocations: ReadonlyArray<Revocation> | undefined,
-): Revocation | null => {
+export const openWindow = <A extends { readonly supersededBy: Oid | null }>(
+  revocations: ReadonlyArray<A> | undefined,
+): A | null => {
   const last = revocations?.at(-1);
   return last !== undefined && last.supersededBy === null ? last : null;
 };
@@ -145,6 +165,8 @@ export interface Projection {
   /** The log head this state was folded from; `null` when the log is empty. */
   readonly head: Oid | null;
   readonly members: ReadonlyMap<Fingerprint, Member>;
+  /** Membership granted to stable identities rather than individual keys. */
+  readonly principals: ReadonlyMap<PrincipalId, PrincipalMember>;
   /**
    * What revoked members held before they were revoked.
    *
@@ -155,6 +177,7 @@ export interface Projection {
    * every past event by anyone who ever left.
    */
   readonly former: ReadonlyMap<Fingerprint, Member>;
+  readonly formerPrincipals: ReadonlyMap<PrincipalId, PrincipalMember>;
   /**
    * Every window each key has been out on, oldest first.
    *
@@ -166,6 +189,7 @@ export interface Projection {
    * every signature they made during the compromise was authorized again.
    */
   readonly revoked: ReadonlyMap<Fingerprint, ReadonlyArray<Revocation>>;
+  readonly revokedPrincipals: ReadonlyMap<PrincipalId, ReadonlyArray<PrincipalRevocation>>;
   readonly roots: ReadonlyArray<RootKey>;
   readonly threshold: number;
   /** The most recent checkpoint, for callers that only want to show one. */
@@ -283,8 +307,11 @@ export const project = Effect.fn("trust.Projection.project")(function* (genesis:
   const head = yield* repository.resolve(Log.LOG_REF);
 
   const members = new Map<Fingerprint, Member>();
+  const principals = new Map<PrincipalId, PrincipalMember>();
   const former = new Map<Fingerprint, Member>();
+  const formerPrincipals = new Map<PrincipalId, PrincipalMember>();
   const revoked = new Map<Fingerprint, ReadonlyArray<Revocation>>();
+  const revokedPrincipals = new Map<PrincipalId, ReadonlyArray<PrincipalRevocation>>();
   const rejected: Rejected[] = [];
 
   let roots: ReadonlyArray<RootKey> = genesis.roots;
@@ -377,8 +404,48 @@ export const project = Effect.fn("trust.Projection.project")(function* (genesis:
         }
       }
 
-      // SAFETY: `Certificate.validate` has checked that `subject` is the
-      // fingerprint of `publicKey`, which is what a `Fingerprint` names.
+      const principal = principalOf(payload.subject);
+
+      if (principal !== null) {
+        const windows = revokedPrincipals.get(principal) ?? [];
+        if (
+          openWindow(windows) !== null &&
+          !quorum &&
+          holds(members, revoked, signers, "member.revoke", claimedAt) === null
+        ) {
+          rejected.push({
+            commit: entry.commit,
+            reason: `issuer may not re-instate ${payload.subject}; that needs member.revoke`,
+          });
+          continue;
+        }
+
+        const previous = principals.get(principal) ?? formerPrincipals.get(principal);
+        principals.set(principal, {
+          principal,
+          hints: payload.identityRepo?.hint ?? [],
+          capabilities: payload.capabilities,
+          grantedAt: new Date(payload.issuedAt),
+          expiresAt: payload.expiresAt === null ? null : new Date(payload.expiresAt),
+          grant: entry.commit,
+          history: [
+            ...(previous?.history ?? []),
+            { commit: entry.commit, capabilities: payload.capabilities },
+          ],
+        });
+        const ending = openWindow(windows);
+        if (ending !== null) {
+          revokedPrincipals.set(principal, [
+            ...windows.slice(0, -1),
+            { ...ending, supersededBy: entry.commit },
+          ]);
+        }
+        formerPrincipals.delete(principal);
+        continue;
+      }
+
+      // SAFETY: `Certificate.validate` has checked that a non-principal
+      // `subject` is the fingerprint of the public key carried beside it.
       const subject = payload.subject as Fingerprint;
 
       // A grant over a revocation re-instates — rotating a key back in is an
@@ -405,9 +472,14 @@ export const project = Effect.fn("trust.Projection.project")(function* (genesis:
       // a fresh start, and the events signed under the old grant were
       // authorized when they were made.
       const previous = members.get(subject) ?? former.get(subject);
+      const publicKey = payload.publicKey;
+      if (publicKey === undefined) {
+        rejected.push({ commit: entry.commit, reason: `${subject} carries no public key` });
+        continue;
+      }
       members.set(subject, {
         fingerprint: subject,
-        publicKey: payload.publicKey,
+        publicKey,
         capabilities: payload.capabilities,
         grantedAt: new Date(payload.issuedAt),
         expiresAt: payload.expiresAt === null ? null : new Date(payload.expiresAt),
@@ -442,7 +514,39 @@ export const project = Effect.fn("trust.Projection.project")(function* (genesis:
         rejected.push({ commit: entry.commit, reason: "issuer may not revoke members" });
         continue;
       }
-      // SAFETY: `Certificate.validate` has checked the subject is a fingerprint.
+      const principal = principalOf(payload.subject);
+      if (principal !== null) {
+        const compromised = payload.reason === "compromised";
+        const from = !compromised
+          ? null
+          : payload.compromisedAt !== null
+            ? new Date(payload.compromisedAt)
+            : ((principals.get(principal) ?? formerPrincipals.get(principal))?.grantedAt ??
+              new Date(0));
+        const windows = revokedPrincipals.get(principal) ?? [];
+        const already = openWindow(windows);
+        const record: PrincipalRevocation = {
+          subject: principal,
+          supersededBy: null,
+          reason:
+            already?.reason === "compromised" || payload.reason === "compromised"
+              ? "compromised"
+              : payload.reason,
+          compromisedFrom: earliest(already?.compromisedFrom ?? null, from),
+          commit: already?.commit ?? entry.commit,
+        };
+        revokedPrincipals.set(
+          principal,
+          already === null ? [...windows, record] : [...windows.slice(0, -1), record],
+        );
+        const held = principals.get(principal);
+        if (held !== undefined) formerPrincipals.set(principal, held);
+        principals.delete(principal);
+        continue;
+      }
+
+      // SAFETY: `Certificate.validate` has checked a non-principal subject is
+      // a fingerprint.
       const subject = payload.subject as Fingerprint;
       const compromised = payload.reason === "compromised";
       const from = !compromised
@@ -533,8 +637,11 @@ export const project = Effect.fn("trust.Projection.project")(function* (genesis:
     repoId: genesis.repoId,
     head,
     members,
+    principals,
     former,
+    formerPrincipals,
     revoked,
+    revokedPrincipals,
     roots,
     threshold,
     checkpoint: retained[0] ?? null,

--- a/src/trust/Verify.ts
+++ b/src/trust/Verify.ts
@@ -28,6 +28,8 @@ import type { Repository } from "../git/Repository.ts";
 import type { Oid } from "../git/Store.ts";
 import { MAX_SIGNATURES, permits } from "./Certificate.ts";
 import * as Log from "./Log.ts";
+import * as Principal from "./Principal.ts";
+import type { PrincipalId } from "./Principal.ts";
 import { type Member, openWindow, type Projection } from "./Projection.ts";
 
 /**
@@ -63,7 +65,12 @@ export type Membership = (
 ) => Effect.Effect<boolean, Invalid | ObjectNotFound | StorageFailure, Repository>;
 
 export type Authorization =
-  | { readonly ok: true; readonly principal: Member }
+  | {
+      readonly ok: true;
+      readonly principal: Member;
+      /** Present when authority resolved through a foreign identity repository. */
+      readonly identity?: Principal.ResolvedIdentity;
+    }
   | { readonly ok: false; readonly reason: string };
 
 const denied = (reason: string): Authorization => ({ ok: false, reason });
@@ -97,15 +104,19 @@ export const signers = Effect.fn("trust.Verify.signers")(function* (
  * reason is forward-only and reaches only what the author made *after* they
  * could see it.
  */
-const reaches = Effect.fn("trust.Verify.reaches")(function* (
-  projection: Projection,
-  subject: Fingerprint,
+const reachesWindows = Effect.fn("trust.Verify.reachesWindows")(function* (
+  revocations:
+    | ReadonlyArray<{
+        readonly supersededBy: Oid | null;
+        readonly commit: Oid;
+        readonly compromisedFrom: Date | null;
+      }>
+    | undefined,
   made: Made | null,
   seen: Ancestry,
   held: Membership,
   permanent = false,
 ) {
-  const revocations = projection.revoked.get(subject);
   if (revocations === undefined || revocations.length === 0) return false;
 
   // A live request is held to the current state: revoked is revoked, and a
@@ -169,6 +180,34 @@ const reaches = Effect.fn("trust.Verify.reaches")(function* (
   return false;
 });
 
+const reaches = Effect.fn("trust.Verify.reaches")(function* (
+  projection: Projection,
+  subject: Fingerprint,
+  made: Made | null,
+  seen: Ancestry,
+  contains: Membership,
+  permanent = false,
+) {
+  return yield* reachesWindows(projection.revoked.get(subject), made, seen, contains, permanent);
+});
+
+const reachesPrincipal = Effect.fn("trust.Verify.reachesPrincipal")(function* (
+  projection: Projection,
+  subject: PrincipalId,
+  made: Made | null,
+  seen: Ancestry,
+  contains: Membership,
+  permanent = false,
+) {
+  return yield* reachesWindows(
+    projection.revokedPrincipals.get(subject),
+    made,
+    seen,
+    contains,
+    permanent,
+  );
+});
+
 /**
  * Whether the grant a member's capabilities come from was already visible.
  *
@@ -204,7 +243,8 @@ const held = Effect.fn("trust.Verify.held")(function* (
   );
   if (ancestors === null) return false;
   for (let at = member.history.length - 1; at >= 0; at--) {
-    const record = member.history[at]!;
+    const record = member.history[at];
+    if (record === undefined) continue;
     if (record.commit !== made.trustHead && !ancestors.has(record.commit)) continue;
     return permits(record.capabilities, capability);
   }
@@ -335,6 +375,67 @@ export const authorize = Effect.fn("trust.Verify.authorize")(function* (input: {
     return { ok: true, principal: member } as const;
   }
 
+  // A stable principal grant is a second membership route, not authority from
+  // the social graph. The target repository granted the capabilities; the
+  // foreign identity log answers which key spoke. Stored events are judged
+  // against the target repository's own grant history and revocation windows,
+  // exactly as direct-key membership is above — otherwise granting a
+  // principal today would retroactively authorize everything that principal
+  // signed before this repository knew them.
+  for (const signer of found) {
+    if (openWindow(input.projection.revoked.get(signer)) !== null) continue;
+    const resolved = yield* Principal.resolveKeyCandidates({
+      projection: input.projection,
+      signer,
+      includeFormer: made !== null,
+    });
+    for (const match of resolved.matches) {
+      if (
+        yield* reachesPrincipal(
+          input.projection,
+          match.grant.principal,
+          made,
+          ancestry,
+          membership,
+          input.permanent === true,
+        )
+      ) {
+        closest = `${match.grant.principal} has been revoked`;
+        continue;
+      }
+      if (
+        input.permanent !== true &&
+        match.principal.expiresAt !== null &&
+        match.principal.expiresAt.getTime() <= Date.now()
+      ) {
+        closest = `${match.grant.principal}'s membership expired on ${match.principal.expiresAt.toISOString()}`;
+        continue;
+      }
+      if (made === null) {
+        if (!permits(match.principal.capabilities, input.capability)) continue;
+      } else if (
+        // A stable-identity grant did not exist in legacy hub v1. An event
+        // that names no project trust head therefore cannot prove that this
+        // repository had granted the principal when it was signed; treating
+        // `null` as today's grant would authorize old foreign signatures
+        // retroactively.
+        made.trustHead === null ||
+        !(yield* held(match.principal, input.capability, made, ancestry))
+      ) {
+        closest = `${match.grant.principal} did not hold ${input.capability} when this was signed`;
+        continue;
+      }
+      return {
+        ok: true,
+        principal: match.principal,
+        identity: match.identity,
+      } as const;
+    }
+    if (resolved.unavailable) {
+      closest = "a referenced identity repository has not been synchronized";
+    }
+  }
+
   return denied(closest);
 });
 
@@ -354,13 +455,25 @@ export const authorizeKey = Effect.fn("trust.Verify.authorizeKey")(function* (in
   }
 
   const member = input.projection.members.get(input.signer);
-  if (member === undefined) return denied(`${input.signer} is not a member of this repository`);
+  if (member === undefined) {
+    const resolved = yield* Principal.authorizeKey(input);
+    if (resolved.ok) {
+      return { ok: true, principal: resolved.principal, identity: resolved.identity } as const;
+    }
+    return resolved.quarantined
+      ? ({ ok: false, reason: resolved.reason, quarantined: true } as const)
+      : ({ ok: false, reason: resolved.reason } as const);
+  }
 
   const when = input.at ?? new Date();
   if (member.expiresAt !== null && member.expiresAt.getTime() <= when.getTime()) {
     return denied(`${input.signer}'s membership expired on ${member.expiresAt.toISOString()}`);
   }
   if (!permits(member.capabilities, input.capability)) {
+    const resolved = yield* Principal.authorizeKey(input);
+    if (resolved.ok) {
+      return { ok: true, principal: resolved.principal, identity: resolved.identity } as const;
+    }
     return denied(`${input.signer} does not hold ${input.capability}`);
   }
   return { ok: true, principal: member } as const;


### PR DESCRIPTION
A design answer to 'how could a web of trust / social graph be overlaid to support decentralized collaboration': principals as identity repositories (PrincipalID = RepoID), an append-only refs/social/log of signed attestations, vouches and follows, verifier-rooted projection with attenuation and independent-path confidence, and the applications — introduction over blind TOFU, cross-repository membership, fork federation with opt-in external review, and follow-driven discovery. Strictly an overlay: nothing in hub v1 changes, and the web never satisfies a capability check on its own.


Claude-Session: https://claude.ai/code/session_01NtGbRQLmWmpo1tDmThwofv